### PR TITLE
Control shutdown of router with custom script

### DIFF
--- a/release/src/router/httpd/web.c
+++ b/release/src/router/httpd/web.c
@@ -3740,6 +3740,7 @@ static int ej_set_variables(int eid, webs_t wp, int argc, char_t **argv) {
 		}
 	}
 	else if(!strcmp(apiName, "qos")){
+		if (shutdown_start("httpd", __FUNCTION__, apiName, apiAction) == 0) {
 		char *desc, *addr, *port, *prio, *transferred, *proto;
 
 		if(!strcmp(apiAction, "enable")){
@@ -3934,6 +3935,7 @@ static int ej_set_variables(int eid, webs_t wp, int argc, char_t **argv) {
 		else{
 				retStatus = 3;
 		}
+		} // if shutdown_start
 	}
 	else{
 		retStatus = 3;
@@ -10136,10 +10138,12 @@ apply_cgi(webs_t wp, char_t *urlPrefix, char_t *webDir, int arg,
 	}
 	else if (!strcmp(action_mode, " Restart ")||!strcmp(action_mode, "reboot"))
 	{
+		if (shutdown_start("httpd", __FUNCTION__, action_mode) == 0) {
 		websApply(wp, "Restarting.asp");
 		nvram_set("freeze_duck", "15");
 		shutdown(fileno(wp), SHUT_RDWR);
 		sys_reboot();
+		}
 	}
 	else if (!strcmp(action_mode, "Restore")||!strcmp(action_mode, "restore"))
 	{
@@ -10527,6 +10531,7 @@ wps_finish:
 	}
 	else if (!strcmp(action_mode, "start_simdetect"))
 	{
+		if (shutdown_start("httpd", __FUNCTION__, action_mode) == 0) {
 		char *simdetect;
 
 		simdetect = get_cgi_json("simdetect", root);
@@ -10536,6 +10541,7 @@ wps_finish:
 		nvram_set("freeze_duck", "15");
 		shutdown(fileno(wp), SHUT_RDWR);
 		sys_reboot();
+		}
 	}
 	else if(!strcmp(action_mode, "update_lte_fw")){
 		notify_rc("start_gobi_update");
@@ -11290,6 +11296,7 @@ do_upgrade_post(char *url, FILE *stream, int len, char *boundary)
 static void
 do_upgrade_post(char *url, FILE *stream, int len, char *boundary)
 {
+	if (shutdown_start("httpd", __FUNCTION__, url) == 0) {
 	#define MAX_VERSION_LEN 64
 
 	do_html_get(url, len, boundary);
@@ -11525,12 +11532,14 @@ err:
 	while (len-- > 0)
 		if((ch = fgetc(stream)) == EOF)
 			break;
+	}
 }
 #endif
 
 static void
 do_upgrade_cgi(char *url, FILE *stream)
 {
+	if (shutdown_start("httpd", __FUNCTION__, url) == 0) {
 	/* Reboot if successful */
 	char *autoreboot = safe_get_cgi_json("autoreboot",NULL);
 	char *reset = safe_get_cgi_json("reset",NULL);
@@ -11600,6 +11609,7 @@ do_upgrade_cgi(char *url, FILE *stream)
 			start_dpi_engine_service();
 #endif
 		}
+	}
 	}
 }
 
@@ -11875,6 +11885,7 @@ err:
 static void
 do_upload_cgi(char *url, FILE *stream)
 {
+	if (shutdown_start("httpd", __FUNCTION__, url) == 0) {
 	int ret;
 #if defined(RTCONFIG_SAVEJFFS)
 	int r;
@@ -11924,6 +11935,7 @@ do_upload_cgi(char *url, FILE *stream)
 	{
 		websApply(stream, "UploadError.asp");
 	   	//unlink("/tmp/settings_u.prf");
+	}
 	}
 }
 

--- a/release/src/router/rc/rc.c
+++ b/release/src/router/rc/rc.c
@@ -978,6 +978,14 @@ int main(int argc, char **argv)
 #if !defined(CONFIG_BCMWL5)
     }
 #endif
+
+	if (strcmp(base, "reboot") == 0 || strcmp(base, "halt") == 0) {
+		int result = shutdown_start("rc", "main", base);
+
+		if (result != 0)
+			return result;
+	}
+
 	const applets_t *a;
 	for (a = applets; a->name; ++a) {
 		if (strcmp(base, a->name) == 0) {

--- a/release/src/router/rc/watchdog.c
+++ b/release/src/router/rc/watchdog.c
@@ -3713,9 +3713,11 @@ void timecheck(void)
 		{
 			if (timecheck_reboot(reboot_schedule))
 			{
+				if (shutdown_start("watchdog", __FUNCTION__, "reboot_schedule") == 0) {
 				_dprintf("reboot plan alert...\n");
 				sleep(1);
 				eval("reboot");
+				}
 			}
 		}
 	}
@@ -4713,6 +4715,7 @@ void swmode_check()
 	else if (flag_sw_mode == 1 && nvram_invmatch("asus_mfg", "1")) {
 		if (sw_mode != pre_sw_mode) {
 			if (++count_stable>4) { // stable for more than 5 second
+				if (shutdown_start("watchdog", __FUNCTION__, "resetdefault") == 0) {
 				dbg("Reboot to switch sw mode ..\n");
 				flag_sw_mode=0;
 				/* sw mode changed: restore defaults */
@@ -4721,6 +4724,7 @@ void swmode_check()
 				nvram_set("restore_defaults", "1");
 				if (notify_rc_after_wait("resetdefault")) {     /* Send resetdefault rc_service failed. */
 					alarmtimer(NORMAL_PERIOD, 0);
+				}
 				}
 			}
 		}
@@ -4748,6 +4752,7 @@ void swmode_check()
 		if (tmp_sw_mode == sw_mode) {
 			if (++count_stable>4) // stable for more than 5 second
 			{
+				if (shutdown_start("watchdog", __FUNCTION__, "reboot") == 0) {
 				dbg("Reboot to switch sw mode ..\n");
 				flag_sw_mode=0;
 				sync();
@@ -4755,6 +4760,7 @@ void swmode_check()
 				nvram_set("nvramver", "0");
 				nvram_commit();
 				reboot(RB_AUTOBOOT);
+				}
 			}
 		}
 		else flag_sw_mode = 0;
@@ -5599,6 +5605,12 @@ static void auto_firmware_check()
 			if (!nvram_get_int("webs_state_flag"))
 			{
 				dbg("no need to upgrade firmware\n");
+				return;
+			}
+
+			if (shutdown_start("watchdog", __FUNCTION__, "auto_upgrade") != 0)
+			{
+				dbg("shutdown-start canceled the auto upgrade because it would reboot\n");
 				return;
 			}
 

--- a/release/src/router/shared/shared.h
+++ b/release/src/router/shared/shared.h
@@ -1744,6 +1744,9 @@ extern void run_custom_script_blocking(char *name, char *args);
 extern void run_postconf(char *name, char *config);
 extern void use_custom_config(char *config, char *target);
 extern void append_custom_config(char *config, FILE *fp);
+#define shutdown_start(args...) _shutdown_start(args, NULL)
+extern int _shutdown_start(const char *cmd, ...);
+extern int _shutdown_start_str(const char *args);
 
 /* mt7620.c */
 #if defined(RTCONFIG_RALINK_MT7620)


### PR DESCRIPTION
### Controlled shutdown of router with custom script
This patch allows the user to define a custom script named `shutdown-start`, and optionally cancel a reboot or halt.  I've hooked it into most places you expect it to be, like the WebUI, rc , init and watchdog.  I just need better control of the shutdown, so I don't lose any work/data.  I verified it works with both RT-AC68U and RT-AC86U routers.  Just looking for people to help me finish testing this.

### Example
**/jffs/scripts/shutdown-start**
```
#!/bin/sh
#nvram set shutdown_cancel=1  # for testing purposes

wall_write() {
  logger -t $(basename $0) "$1"
  for tty in /dev/pts/*; do
    if [ -c $tty ]; then
      echo "$1" >$tty
    fi
  done
}

wall() {
  if [ -n "$1" ]; then
    wall_write "$1"
  else
    local textline=""
    while read -r textline; do
      wall_write "$textline"
    done
  fi
}

wall "The system is going down in 10 seconds.  Please log off now or you may lose some work."
sleep 10
echo "Bye bye." | wall
sleep 1
```

### Testing the feature
- WebUI/browser: press the Reboot button
    OR
- Shell command: `reboot`
    OR
- Shell command: `kill -TERM 1`
