### PR TITLE
check what p points to and not p for '\0'

### DIFF
--- a/release/src/router/freeradius-server-3.0.0/src/modules/rlm_mschap/rlm_mschap.c
+++ b/release/src/router/freeradius-server-3.0.0/src/modules/rlm_mschap/rlm_mschap.c
@@ -452,7 +452,7 @@ static ssize_t mschap_xlat(void *instance, REQUEST *request,
 		char buf2[1024];
 
 		p = fmt + 8;	/* 7 is the length of 'NT-Hash' */
-		if ((p == '\0')	 || (outlen <= 32))
+		if ((*p == '\0')	 || (outlen <= 32))
 			return 0;
 
 		while (isspace(*p)) p++;
@@ -481,7 +481,7 @@ static ssize_t mschap_xlat(void *instance, REQUEST *request,
 		char buf2[1024];
 
 		p = fmt + 8;	/* 7 is the length of 'LM-Hash' */
-		if ((p == '\0') || (outlen <= 32))
+		if ((*p == '\0') || (outlen <= 32))
 			return 0;
 
 		while (isspace(*p)) p++;


### PR DESCRIPTION
in function mschap_xlat (p== '\0') was being used instead of (*p=='\0')