### PR TITLE
Fix compilation on modern hosts

### DIFF
--- a/release/src-rt-5.02hnd/hostTools/jffs2/mkfs.jffs2.c
+++ b/release/src-rt-5.02hnd/hostTools/jffs2/mkfs.jffs2.c
@@ -49,6 +49,7 @@
 
 #define _GNU_SOURCE
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/release/src-rt-5.02hnd/hostTools/mtd-utils-20090606.patch
+++ b/release/src-rt-5.02hnd/hostTools/mtd-utils-20090606.patch
@@ -64,3 +64,69 @@ diff -ur mtd-utils-20090606_orig/mkfs.ubifs/hashtable/hashtable_itr.h mtd-utils-
  hashtable_iterator_value(struct hashtable_itr *i)
  {
      return i->e->v;
+diff -ur mtd-utils-20090606.orig/mkfs.jffs2.c ./mtd-utils-20090606/mkfs.jffs2.c
+--- ./mtd-utils-20090606.orig/mkfs.jffs2.c        2009-06-05 16:41:47.000000000 +0000
++++ ./mtd-utils-20090606/mkfs.jffs2.c     2019-04-14 07:24:58.857349884 +0000
+@@ -51,6 +51,7 @@
+ #include <sys/types.h>
+ #include <stdio.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <unistd.h>
+ #include <sys/mman.h>
+ #include <fcntl.h>
+diff -ur mtd-utils-20090606.orig/mkfs.ubifs/mkfs.ubifs.h ./mtd-utils-20090606/mkfs.ubifs/mkfs.ubifs.h
+--- ./mtd-utils-20090606.orig/mkfs.ubifs/mkfs.ubifs.h     2009-06-05 16:41:47.000000000 +0000
++++ ./mtd-utils-20090606/mkfs.ubifs/mkfs.ubifs.h  2019-04-14 07:24:58.860683215 +0000
+@@ -39,6 +39,7 @@
+ #include <getopt.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/ioctl.h>
+ #include <fcntl.h>
+ #include <dirent.h>
+diff -ur mtd-utils-20090606.orig/ubi-utils/old-utils/src/libubi.c ./mtd-utils-20090606/ubi-utils/old-utils/src/libubi.c
+--- ./mtd-utils-20090606.orig/ubi-utils/old-utils/src/libubi.c    2009-06-05 16:41:47.000000000 +0000
++++ ./mtd-utils-20090606/ubi-utils/old-utils/src/libubi.c 2019-04-14 07:24:58.880683200 +0000
+@@ -25,6 +25,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <dirent.h>
+ #include <errno.h>
+diff -ur mtd-utils-20090606.orig/ubi-utils/src/libmtd.c ./mtd-utils-20090606/ubi-utils/src/libmtd.c
+--- ./mtd-utils-20090606.orig/ubi-utils/src/libmtd.c      2009-06-05 16:41:47.000000000 +0000
++++ ./mtd-utils-20090606/ubi-utils/src/libmtd.c   2019-04-14 07:24:58.884016531 +0000
+@@ -30,6 +30,7 @@
+ #include <dirent.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/ioctl.h>
+ #include <mtd/mtd-user.h>
+
+diff -ur mtd-utils-20090606.orig/ubi-utils/src/libmtd_legacy.c ./mtd-utils-20090606/ubi-utils/src/libmtd_legacy.c
+--- ./mtd-utils-20090606.orig/ubi-utils/src/libmtd_legacy.c       2009-06-05 16:41:47.000000000 +0000
++++ ./mtd-utils-20090606/ubi-utils/src/libmtd_legacy.c    2019-04-14 07:24:58.884016531 +0000
+@@ -30,6 +30,7 @@
+ #include <errno.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/ioctl.h>
+ #include <mtd/mtd-user.h>
+
+diff -ur mtd-utils-20090606.orig/ubi-utils/src/libubi.c ./mtd-utils-20090606/ubi-utils/src/libubi.c
+--- ./mtd-utils-20090606.orig/ubi-utils/src/libubi.c      2009-06-05 16:41:47.000000000 +0000
++++ ./mtd-utils-20090606/ubi-utils/src/libubi.c   2019-04-14 07:24:58.887349862 +0000
+@@ -29,6 +29,7 @@
+ #include <limits.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <libubi.h>
+ #include "libubi_int.h"

--- a/release/src-rt-5.02hnd/hostTools/squashfs_4.2/mksquashfs.c
+++ b/release/src-rt-5.02hnd/hostTools/squashfs_4.2/mksquashfs.c
@@ -33,6 +33,7 @@
 #include <stddef.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/release/src-rt-5.02hnd/hostTools/squashfs_4.2/unsquashfs.c
+++ b/release/src-rt-5.02hnd/hostTools/squashfs_4.2/unsquashfs.c
@@ -31,6 +31,7 @@
 
 #include <sys/sysinfo.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 struct cache *fragment_cache, *data_cache;
 struct queue *to_reader, *to_deflate, *to_writer, *from_writer;

--- a/release/src/router/libevent-2.0.21/test/Makefile.am
+++ b/release/src/router/libevent-2.0.21/test/Makefile.am
@@ -19,7 +19,14 @@ endif
 EXTRA_PROGRAMS = regress
 noinst_HEADERS = tinytest.h tinytest_macros.h regress.h tinytest_local.h
 
-TESTS = $(top_srcdir)/test/test.sh
+# We need to copy this file, since automake doesn't want us to use top_srcdir
+# in TESTS.
+TESTS = test-script.sh
+
+test-script.sh: test.sh
+	cp $< $@
+
+DISTCLEANFILES = test-script.sh
 
 BUILT_SOURCES =
 if BUILD_REGRESS
@@ -91,7 +98,7 @@ rpcgen-attempted: $(srcdir)/regress.rpc $(srcdir)/../event_rpcgen.py $(srcdir)/r
 
 CLEANFILES = rpcgen-attempted
 
-DISTCLEANFILES = *~
+DISTCLEANFILES += *~
 
 verify: check
 


### PR DESCRIPTION
On Ubuntu Disco (19.04), compilation fails with newer tools like automake and glibc.

Changes:
- **automake**: newer version dislike the use of "top_srcdir" in libevent's Makefile. https://github.com/libevent/libevent/commit/a55514eeed96b9bf9a16fbed1a709dfcce5a6080
- **glibc**: extra include <sys/sysmacros.h> needed for some macros.

Tested on Ubuntu Disco with automake 1.16.1 and glibc 2.29.

_Note: I realize patching a patch file is hack-y, but unfortunately this seems like the least intrusive way without touching the Makefiles._