### PR TITLE
use a standard cssRules (instead of rules) property of CSSStyleSheet

### DIFF
--- a/release/src/router/www/cloud_main.asp
+++ b/release/src/router/www/cloud_main.asp
@@ -307,10 +307,10 @@ function show_partition(){
 function getStyleSheet(cssName, rule) {
 	for (i = 0; i < document.styleSheets.length; i++) {
 		if (document.styleSheets[i].href.toString().indexOf(cssName) != -1) {
-			for (x = 0; x < document.styleSheets[i].rules.length; x++) {
-				if(document.styleSheets[i].rules[x].type == 1) {
-					if (document.styleSheets[i].rules[x].selectorText.toString() == rule) {
-						return document.styleSheets[i].rules[x];
+			for (x = 0; x < document.styleSheets[i].cssRules.length; x++) {
+				if(document.styleSheets[i].cssRules[x].type == 1) {
+					if (document.styleSheets[i].cssRules[x].selectorText.toString() == rule) {
+						return document.styleSheets[i].cssRules[x];
 					}
 				}
 			}


### PR DESCRIPTION
works in Chrome 75 and Firefox 67
"rules" is [non-standard](https://drafts.csswg.org/cssom/#cssstylesheet) and does not work in Firefox 67

This results in an unhandled exception and failure to execute all of the script on the page

The visibile manifestation is that the aicloud Uninstall button remains visible because [this](https://github.com/RMerl/asuswrt-merlin.ng/blob/master/release/src/router/www/cloud_main.asp#L81) line never executes. 