### PR TITLE
remove the radio off confirmation introduced with aimesh

### DIFF
--- a/release/src/router/www/Advanced_WAdvanced_Content.asp
+++ b/release/src/router/www/Advanced_WAdvanced_Content.asp
@@ -761,11 +761,6 @@ function applyRule(){
 		}
 		
 		document.form.wl_sched.value = wifi_schedule_value;	
-		if(amesh_support && (isSwMode("rt") || isSwMode("ap"))) {
-			var radio_value = (document.form.wl_radio[0].checked) ? 1 : 0;
-			if(!AiMesh_confirm_msg("Wireless_Radio",radio_value))
-				return;
-		}
 		showLoading();
 		document.form.submit();
 	}


### PR DESCRIPTION
every time you turn off the radio (which is already a multi-click operation), aimesh enabled firmware confirms with: 

> "If you disable Radio, it will affect the AiMesh wifi connectivity.\nAre you sure to process?"

This wasn't there before aimesh and it's not needed now. The merlin audience does not need to be reminded endlessly that turning off the wifi radio will affect wifi connectivity.