### PR TITLE
rc: fix dnsfilter IPv6 additions to dnsmasq.conf

### DIFF
--- a/release/src/router/rc/dnsfilter.c
+++ b/release/src/router/rc/dnsfilter.c
@@ -256,7 +256,7 @@ void dnsfilter_setup_dnsmasq(FILE *fp) {
 
 	defmode = nvram_get_int("dnsfilter_mode");
 
-	for (dnsmode = 1; dnsmode < (sizeof server_table / sizeof server_table[0]); dnsmode++) {
+	for (dnsmode = 1; dnsmode < (sizeof(server_table)/sizeof(server_table[0])); dnsmode++) {
 		if (dnsmode == defmode)
 			continue;
 		count = get_dns_filter(AF_INET6, dnsmode, server);

--- a/release/src/router/rc/dnsfilter.c
+++ b/release/src/router/rc/dnsfilter.c
@@ -256,7 +256,7 @@ void dnsfilter_setup_dnsmasq(FILE *fp) {
 
 	defmode = nvram_get_int("dnsfilter_mode");
 
-	for (dnsmode = 1; dnsmode < 13; dnsmode++) {
+	for (dnsmode = 1; dnsmode < 17; dnsmode++) {
 		if (dnsmode == defmode)
 			continue;
 		count = get_dns_filter(AF_INET6, dnsmode, server);

--- a/release/src/router/rc/dnsfilter.c
+++ b/release/src/router/rc/dnsfilter.c
@@ -256,7 +256,7 @@ void dnsfilter_setup_dnsmasq(FILE *fp) {
 
 	defmode = nvram_get_int("dnsfilter_mode");
 
-	for (dnsmode = 1; dnsmode < (sizeof(server_table)/sizeof(server_table[0])); dnsmode++) {
+	for (dnsmode = 1; dnsmode < (sizeof(server6_table)/sizeof(server6_table[0])); dnsmode++) {
 		if (dnsmode == defmode)
 			continue;
 		count = get_dns_filter(AF_INET6, dnsmode, server);

--- a/release/src/router/rc/dnsfilter.c
+++ b/release/src/router/rc/dnsfilter.c
@@ -256,7 +256,7 @@ void dnsfilter_setup_dnsmasq(FILE *fp) {
 
 	defmode = nvram_get_int("dnsfilter_mode");
 
-	for (dnsmode = 1; dnsmode < 17; dnsmode++) {
+	for (dnsmode = 1; dnsmode < (sizeof server_table / sizeof server_table[0]); dnsmode++) {
 		if (dnsmode == defmode)
 			continue;
 		count = get_dns_filter(AF_INET6, dnsmode, server);


### PR DESCRIPTION
DNSFilter is only writing IPv6 options 5 & 6 to dnsmasq.conf since the other choices have an index 13 or greater. This change allows the remaining options to be written.