### PR TITLE
other: fix am_get_webui_page() returning new mount point before match…

### DIFF
--- a/release/src/router/others/helper.sh
+++ b/release/src/router/others/helper.sh
@@ -47,11 +47,18 @@ pc_delete() {
 am_get_webui_page() {
 	for i in 1 2 3 4 5 6 7 8 9 10; do
 		page="/www/user/user$i.asp"
-		if [ ! -f "$page" ] || [ "$(md5sum < "$1")" = "$(md5sum < "$page")" ]; then
+		if [ -f "$page" ] && [ "$(md5sum < "$1")" = "$(md5sum < "$page")" ]; then
 			am_webui_page="user$i.asp"
 			return
 		fi
 	done
+	for i in 1 2 3 4 5 6 7 8 9 10; do
+		page="/www/user/user$i.asp"
+		if [ ! -f "$page" ]; then
+			am_webui_page="user$i.asp"
+			return
+		fi
+	done	
 	am_webui_page="none"
 }
 

--- a/release/src/router/others/helper.sh
+++ b/release/src/router/others/helper.sh
@@ -45,21 +45,17 @@ pc_delete() {
 # of the first available mount point, the filename your page is already using,
 # or "none" if there are no available mount points.
 am_get_webui_page() {
-	for i in 1 2 3 4 5 6 7 8 9 10; do
-		page="/www/user/user$i.asp"
-		if [ -f "$page" ] && [ "$(md5sum < "$1")" = "$(md5sum < "$page")" ]; then
-			am_webui_page="user$i.asp"
-			return
-		fi
-	done
-	for i in 1 2 3 4 5 6 7 8 9 10; do
-		page="/www/user/user$i.asp"
-		if [ ! -f "$page" ]; then
-			am_webui_page="user$i.asp"
-			return
-		fi
-	done	
-	am_webui_page="none"
+        am_webui_page="none"
+        # look for a match first in case the page is already there
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+                page="/www/user/user$i.asp"
+                if [ -f "$page" ] && [ "$(md5sum < "$1")" = "$(md5sum < "$page")" ]; then
+                        am_webui_page="user$i.asp"
+                        return
+                elif [ "$am_webui_page" = "none" ] && [ ! -f "$page" ]; then
+                        am_webui_page="user$i.asp"
+                fi
+        done
 }
 
 


### PR DESCRIPTION
…ing existing file

When calling am_get_webui_page, it will return the first available page number even if the current version of the page is already present.

Example:
user1.asp - occupied
user2.asp - empty
user3.asp - my current addon asp page
user4-10.asp - empty

Even though my page at user3.asp is identical to the original source, the function will return user2.asp because it is empty. This is due to the OR condition of file not exist OR md5sum matches.

This PR will check all occupied mount points for a match first, and only if no match is found, it will return the first available mount point.