### PR TITLE
Make VPN policy routing mode work without requiring webui client rules

### DIFF
--- a/release/src/router/others/vpnrouting.sh
+++ b/release/src/router/others/vpnrouting.sh
@@ -163,7 +163,8 @@ then
 	if [ "$VPN_FORCE" -eq 1 ] && [ "$VPN_REDIR" -ge 2 ]
 	then
 		/usr/bin/logger -t "openvpn-routing" "Tunnel down - VPN client access blocked"
-		ip route change prohibit default table $VPN_TBL
+		ip route del default table $VPN_TBL
+		ip route add prohibit default table $VPN_TBL
 		create_client_list
 	else
 		ip route flush table $VPN_TBL
@@ -190,21 +191,14 @@ then
         create_client_list
 
 # Setup table default route
-	if [ -n "$VPN_IP_LIST" ]
+	[ "$VPN_FORCE" -eq 1 ] && /usr/bin/logger -t "openvpn-routing" "Tunnel re-established, restoring WAN access to clients"
+	if [ -n "$route_vpn_gateway" ]
 	then
-		if [ "$VPN_FORCE" -eq 1 ]
-		then
-			/usr/bin/logger -t "openvpn-routing" "Tunnel re-established, restoring WAN access to clients"
-		fi
-		if [ -n "$route_net_gateway" ]
-		then
-			ip route del default table $VPN_TBL
-			ip route add default via $route_vpn_gateway table $VPN_TBL
-		else
-			/usr/bin/logger -t "openvpn-routing" "WARNING: no VPN gateway provided, routing might not work properly!"
-		fi
+		ip route del default table $VPN_TBL
+		ip route add default via $route_vpn_gateway table $VPN_TBL
+	else
+		/usr/bin/logger -t "openvpn-routing" "WARNING: no VPN gateway provided, routing might not work properly!"
 	fi
-
 	if [ -n "$route_net_gateway" ]
 	then
 		ip route del default


### PR DESCRIPTION
Ensure default route for ovpnc* table always gets set and that killswitch always adds prohibit rule.

As it is now, if you want to setup a VPN client using custom IPSET routing or similar, you have to either do it completely manually, or define a dummy client in the webui in order for the routing table to be built properly. Unless I'm missing something, there is no reason not to always create the client routing table. 

Aside from the base logic fix, I also changed the condition used for adding the client routing table default route, since I believe it was an actual bug. If it was indeed correct before, I will change that condition back. The line in question is 199/195 `if [ -n "$route_net_gateway" ]` -> `if [ -n "$route_vpn_gateway" ]`

Tested on an RT-AC68U by mounting my version over `/usr/sbin/vpnrouting.sh`