### PR TITLE
Fix vpn server access in LAN-only and WAN-only modes

### DIFF
--- a/release/src/router/shared/network_utility.c
+++ b/release/src/router/shared/network_utility.c
@@ -2,12 +2,13 @@
 #include <stdio.h>
 #include <arpa/inet.h>
 
-int bit_count(uint32_t i)
+int bit_count(in_addr_t i)
 {
 	int c = 0;
 	unsigned int seen_one = 0;
 
-	while (i > 0) {
+	// Be sure to check all octets
+	for (int b = 0; i > 0 || b < 25; ++b, i >>= 1) {
 		if (i & 1) {
 			seen_one = 1;
 			c++;
@@ -16,7 +17,6 @@ int bit_count(uint32_t i)
 				return -1;
 			}
 		}
-		i >>= 1;
 	}
 
 	return c;
@@ -24,7 +24,7 @@ int bit_count(uint32_t i)
 
 int convert_subnet_mask_to_cidr(const char *mask)
 {
-	unsigned long n;
+	in_addr_t n;
 	
 	if(!mask)
 		return -1;
@@ -32,7 +32,7 @@ int convert_subnet_mask_to_cidr(const char *mask)
 	if(inet_pton(AF_INET, mask, &n) != 1)
 		return -1;
 
-	return bit_count(n);
+	return bit_count(ntohl(n));
 }
 
 


### PR DESCRIPTION
Fix the `convert_subnet_mask_to_cidr` from `network_utils.c` to work correctly when the LAN netmask contains values other than 255 or 0 on little endian systems.

There is a missing byte-order conversion before calling `bit_count`. This caused a value of -1 to be returned even for valid masks. As a result, the firewall rules generated for a VPN server would end up with an invalid rule like below which prevented the server from working:
`iptables -I OVPN -i tun22 ! -d 192.168.1.1/-1 -j ACCEPT`

Also made a slight adjustment to `bit_count` to correctly treat malformed masks such as `0.255.255.0` as invalid.

Tested using the attached test program compiled and run on an RT-AC68U running firmware 384.19. The output is as follows:
[cidr_fix.c](https://github.com/RMerl/asuswrt-merlin.ng/files/5440343/cidr_fix.c.txt)

```
# ./cidr_fix 255.255.255.255 255.255.255.0 255.255.0.0 255.0.0.0 255.255.254.0 255.255.127.0 0.255.255.0 255.254.255.0
Original: 255.255.255.255 = 32
Fixed:    255.255.255.255 = 32

Original: 255.255.255.0 = 24
Fixed:    255.255.255.0 = 24

Original: 255.255.0.0 = 16
Fixed:    255.255.0.0 = 16

Original: 255.0.0.0 = 8
Fixed:    255.0.0.0 = 8

Original: 255.255.254.0 = -1
Fixed:    255.255.254.0 = 23

Original: 255.255.127.0 = 23
Fixed:    255.255.127.0 = -1

Original: 0.255.255.0 = 16
Fixed:    0.255.255.0 = -1

Original: 255.254.255.0 = -1
Fixed:    255.254.255.0 = -1
```