### PR TITLE
webui: stop processing more filters once connection is excluded

### DIFF
--- a/release/src/router/www/QoS_Stats.asp
+++ b/release/src/router/www/QoS_Stats.asp
@@ -274,7 +274,7 @@ function draw_conntrack_table(){
 						filtered = 1;
 					}
 				}
-				if (filtered) continue;
+				if (filtered) break;
 			}
 		}
 		if (filtered) continue;


### PR DESCRIPTION
As soon as a connection is excluded by the first populated filter, stop checking additional filters and proceed to the next connection in the loop.