### PR TITLE
Fixed OpenVPN 'Initializing' typo in EN dictionary

### DIFF
--- a/release/src/router/www/EN.dict
+++ b/release/src/router/www/EN.dict
@@ -3341,7 +3341,7 @@ vpn_openvpn_fail4=OpenVPN server daemon failed to start. <p>Please check your de
 vpn_openvpn_hint1=To use your own key, click the yellow link to modify settings.
 vpn_openvpn_hint2=Refer to the <a style="font-weight: bolder;text-decoration:underline;" class="hyperlink" href="Main_LogStatus_Content.asp">System Log</a> for any error messages related to OpenVPN.
 vpn_openvpn_hint3=Before configuring the advanced settings of the OpenVPN server, ensure that these advanced settings options are compatible with the OpenVPN software in the client devices.
-vpn_openvpn_init=Initialinzing the settings of OpenVPN server now, please wait a few minutes to let the server to setup completed before VPN clients establish the connection.
+vpn_openvpn_init=Initializing the settings of OpenVPN server now, please wait a few minutes to let the server to setup completed before VPN clients establish the connection.
 vpn_openvpn_interface=Interface Type
 vpn_openvpn_KC_Authorizing=Authorizing
 vpn_openvpn_KC_CA=Certificate Authority


### PR DESCRIPTION
`Initializing` misspelled as `Initialinzing` in the EN dictionary's `vpn_openvpn_init` key