### PR TITLE
iproute2-4.3: fix display of negative deficit and drop_next values

### DIFF
--- a/release/src/router/iproute2-4.3/iproute2-4.3.0/tc/q_cake.c
+++ b/release/src/router/iproute2-4.3/iproute2-4.3.0/tc/q_cake.c
@@ -678,7 +678,7 @@ static int cake_print_xstats(struct qdisc_util *qu, FILE *f,
 
 	/* class stats */
 	if (st[TCA_CAKE_STATS_DEFICIT])
-		fprintf(f, "  deficit %u",
+		fprintf(f, "  deficit %d",
 			  GET_STAT_S32(DEFICIT));
 	if (st[TCA_CAKE_STATS_COBALT_COUNT])
 		fprintf(f, " count %u",

--- a/release/src/router/iproute2-4.3/iproute2-4.3.0/tc/q_cake.c
+++ b/release/src/router/iproute2-4.3/iproute2-4.3.0/tc/q_cake.c
@@ -691,7 +691,7 @@ static int cake_print_xstats(struct qdisc_util *qu, FILE *f,
 
 			if (drop_next < 0) {
 				fprintf(f, " drop_next -%s",
-					sprint_time(drop_next, b1));
+					sprint_time(-drop_next, b1));
 			} else {
 //				print_uint(PRINT_JSON, "drop_next", NULL,
 //					drop_next);


### PR DESCRIPTION
Address negative deficit values overflowing on stats output.
```
# tc -s class show dev eth0
class cake 8005:42b parent 8005:
 (dropped 44, overlimits 0 requeues 0)
 backlog 10598b 7p requeues 0
  deficit 4294967060 count 16 dropping drop_next -4295.0s blue_prob 0
```