### PR TITLE
Fix NetEase UU Game Accelerator model type

### DIFF
--- a/release/src/router/www/UUAccelerator.asp
+++ b/release/src/router/www/UUAccelerator.asp
@@ -24,7 +24,7 @@ function initial(){
 }
 function uuRegister(mac){
 	var _mac = mac.toLowerCase();
-	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt', '_blank');
+	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt-merlin', '_blank');
 }
 </script>
 </head>

--- a/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameBoost.asp
+++ b/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameBoost.asp
@@ -117,7 +117,7 @@ function redirectSite(url){
 
 function uuRegister(mac){
 	var _mac = mac.toLowerCase();
-	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt', '_blank');
+	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt-merlin', '_blank');
 }
 </script>
 </head>

--- a/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameDashboard.asp
+++ b/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameDashboard.asp
@@ -1061,7 +1061,7 @@ function hideEventTriggerDesc(){
 }
 function uuRegister(mac){
 	var _mac = mac.toLowerCase();
-	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt', '_blank');
+	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt-merlin', '_blank');
 }
 </script>
 </head>


### PR DESCRIPTION
When the type is "asuswrt", the Accelerator web UI show "The router fails to connect to the network" and can't work as expected
Modify the URL to "type=asuswrt-merlin", it work normally again
tested on AC88u AX88u AC86u AX86u AC1900P

refer:

router type define
install.sh from https://router.uu.163.com/api/script/install?type=asuswrt-merlin
uuplugin_monitor.sh from https://router.uu.163.com/api/script/monitor?type=asuswrt-merlin

fourm solution discussion
https://koolshare.cn/forum.php?mod=redirect&goto=findpost&ptid=179485&pid=2417559
https://koolshare.cn/forum.php?mod=viewthread&tid=179485
https://koolshare.cn/forum.php?mod=redirect&goto=findpost&ptid=192048&pid=2515316