### PR TITLE
Revert "Revert "Fix NetEase UU Game Accelerator model type"" and why

### DIFF
--- a/release/src/router/www/UUAccelerator.asp
+++ b/release/src/router/www/UUAccelerator.asp
@@ -24,7 +24,7 @@ function initial(){
 }
 function uuRegister(mac){
 	var _mac = mac.toLowerCase();
-	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt', '_blank');
+	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt-merlin', '_blank');
 }
 </script>
 </head>

--- a/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameBoost.asp
+++ b/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameBoost.asp
@@ -117,7 +117,7 @@ function redirectSite(url){
 
 function uuRegister(mac){
 	var _mac = mac.toLowerCase();
-	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt', '_blank');
+	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt-merlin', '_blank');
 }
 </script>
 </head>

--- a/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameDashboard.asp
+++ b/release/src/router/www/sysdep/FUNCTION/ROG_UI/GameDashboard.asp
@@ -1061,7 +1061,7 @@ function hideEventTriggerDesc(){
 }
 function uuRegister(mac){
 	var _mac = mac.toLowerCase();
-	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt', '_blank');
+	window.open('https://router.uu.163.com/asus/pc.html#/acce?gwSn=' + _mac + '&type=asuswrt-merlin', '_blank');
 }
 </script>
 </head>


### PR DESCRIPTION
Reverts RMerl/asuswrt-merlin.ng#715

> If you want to fix this problem, move exec_uu() from ntp.c to services.c, see start_qmacc(), just like it. uu and qmacc only work when tcode is CN, it is safe.

First, All Accelerator (UU Game Booster and Tencent Game Accelerator) we discuss are **firmware embedded edition** (both have web control interface and app control interface, can remote control in the internet, not **APP install plugin edition** (only can control with APP in the same local area network).

As u know, merlin Use NTP daemon(ntpd) 
u are a famous mod firmware author that base on asus official firmware, not base on merlin (refer u patch note: https://update.paldier.com/log.txt and u blog:https://blog.paldier.com/)
Allmost all u firmware release article's first sentence is “基于华硕官方源代码而非merlin代码” (based on ASUS offical source code instead of merlin code)

Notice the difference between "official"（官方） and "offcial mod"(官方改版 or 官改）and "merlin mod" (梅林改版 or ML改版）
offcial mod firmware only add "software center" to official firmware, so offcial mod firmware can use "type=asuswrt"
merlin and merlin mod firmware can't use "type=asuswrt" to start running the game accelerator

"type=asuswrt" is redirect to a shell script file for official or official mod firmware, not for merlin
so why merlin's author need to fix the offical firmeware shell script ("type=asuswrt") ,instead of use merlin shell script ("type=asuswrt-merlin"), specifically for merlin firmware

the UU Game Booster firmware embedded edition web control interface:
https://router.uu.163.com/asus/pc.html#/acce?gwSn=AA:BB:CC:DD:EE:FF&type=

If "type=asuswrt" the router will install https://router.uu.163.com/api/plugin?type=asuswrt-{lowercasemodelwithout-}, which will work correctly on official firmware or official mod firmware

If "type=asuswrt-merlin" the router will install https://router.uu.163.com/api/plugin?type=asuswrt-merlin, which will work correctly on merlin firmware or merlin mod firmware

> If "**type=asuswrt**" and firmware is **official or official mod version**:
binary tar file:
https://router.uu.163.com/api/plugin?type=asuswrt-merlin-ac88u or https://router.uu.163.com/api/plugin?type=asuswrt-rtax88u
(https://router.uu.163.com/api/plugin?type=asuswrt-{lowercasemodelwithout-})
monitor file:
https://router.uu.163.com/api/script/monitor?type=asuswrt

> If "**type=asuswrt-merlin**" and firmware is **merlin**:
binary tar file:
https://router.uu.163.com/api/plugin?type=asuswrt-merlin
monitor file:
https://router.uu.163.com/api/script/monitor?type=asuswrt-merlin

> If device is third-party and firmware is merlin:
binary tar file:
https://router.uu.163.com/api/plugin?type=merlin-armv7
https://router.uu.163.com/api/plugin?type=merlin-armv8
https://router.uu.163.com/api/plugin?type=linksys-merlin-ea6400
https://router.uu.163.com/api/plugin?type=netgear-merlin-r6400

base on monitor shell script file from https://router.uu.163.com/api/script/monitor?type=asuswrt
(https://uu.gdl.netease.com/asuswrt/r201910101020/uuplugin_monitor.sh)
https://router.uu.163.com/api/plugin?type=asuswrt-{lowercasemodelwithout-}&sn={mac}
this plugin can't running on merlin firmware without u fix solution