### PR TITLE
rom: Only source profile.add when custom configs enabled

### DIFF
--- a/release/src/router/rom/rom/etc/profile
+++ b/release/src/router/rom/rom/etc/profile
@@ -11,4 +11,4 @@ ldd() {
 [ -n "${TMOUT+x}" ] || export TMOUT="$(nvram get shell_timeout 2>/dev/null)"
 
 [ -f /opt/etc/profile ] && . /opt/etc/profile
-[ -f /jffs/configs/profile.add ] && . /jffs/configs/profile.add
+[ "$(nvram get jffs2_scripts)" = "1" ] && [ -f /jffs/configs/profile.add ] && . /jffs/configs/profile.add

--- a/release/src/router/rom/rom/etc/profile.hnd
+++ b/release/src/router/rom/rom/etc/profile.hnd
@@ -13,5 +13,5 @@ ldd() {
 
 [ -f /jffs/etc/profile ] && . /jffs/etc/profile
 [ -f /opt/etc/profile ] && . /opt/etc/profile
-[ -f /jffs/configs/profile.add ] && . /jffs/configs/profile.add
+[ "$(nvram get jffs2_scripts)" = "1" ] && [ -f /jffs/configs/profile.add ] && . /jffs/configs/profile.add
 


### PR DESCRIPTION
/jffs/configs/profile.add is sourced by /etc/profile regardless of the state of “Enable JFFS custom scripts and configs“. This PR will only source the profile if JFFS custom scripts and configs is enabled. This would be in alignment with the rest of the custom config files’ behavior.