### PR TITLE
Avoid starting DNSMASQ when in repeater mode

### DIFF
--- a/release/src/router/rc/watchdog.c
+++ b/release/src/router/rc/watchdog.c
@@ -6515,7 +6515,7 @@ void dnsmasq_check()
 
 	if (!is_routing_enabled()
 #ifdef RTCONFIG_WIRELESSREPEATER
-		&& sw_mode() != SW_MODE_REPEATER
+		|| sw_mode() == SW_MODE_REPEATER
 #endif
 	)
 		return;


### PR DESCRIPTION
Logs filled with 'watchdog 250:notify_rc start_dnsmasq' every 30 seconds if the device (AC68U) is in repeater mode.
The condition seems to be wrong, fixed.