### PR TITLE
kernel 2.6.36: restore ip6_tables set-return code

### DIFF
--- a/release/src-rt-6.x.4708/linux/linux-2.6.36/net/ipv6/netfilter/ip6_tables.c
+++ b/release/src-rt-6.x.4708/linux/linux-2.6.36/net/ipv6/netfilter/ip6_tables.c
@@ -431,6 +431,14 @@ ip6t_do_table(struct sk_buff *skb,
 		verdict = t->u.kernel.target->target(skb, &acpar);
 		if (verdict == IP6T_CONTINUE)
 			e = ip6t_next_entry(e);
+		else if (verdict == IP6T_RETURN) {		// added -- zzz
+			if (*stackptr == 0)
+				e = get_entry(table_base,
+				    private->underflow[hook]);
+			else
+				e = ip6t_next_entry(jumpstack[--*stackptr]);
+			continue;
+		}
 		else
 			/* Verdict */
 			break;


### PR DESCRIPTION
The netfilters in the 2.6.22 and 2.6.36 kernels have an addition to
their CONNMARK support that lets the CONNMARK target act as a RETURN via
the --set-return option.

This is signalled by the connmark target function returning `XT_RETURN`.

However this is not standard Linux behaviour - target functions are not
supposed to jump - so to support it `ipt_do_table` and `ip6t_do_table`
need added code that checks for and handles `XT_RETURN` in the same way
as they would handle the standard RETURN target.

Kernel 2.6.22 had this code. The initial 2.6.36 kernel was missing the
code, and had the `return XT_RETURN` in `connmark_tg` disabled. Later,
the code was restored to `ipt_do_table` and `return XT_RETURN` was put
back. However, the code was never restored to `ip6t_do_table`.

By inspection, this means that traditional QoS will not work correctly
for IPv6 traffic with kernel 2.6.36 - it may even cause traffic loss.

The LTS fork actually has the `return XT_RETURN` removed, which means
QoS categorisation won't work for either IPv4 or IPv6, but would avoid
packet loss.

This patch adds the necessary code to `ip6t_do_table`, which should make
everything work as well as it ever did.

Systems using newer kernels abandoned this `set-return` and use standard
`RETURN` targets instead, so will have no problem.

A possible alternative would be to modify userspace to always use
standard `RETURN` targets. This might avoid any other issues arising
from this non-standard extension, but would increase CPU load on old
systems due to the extra table entries.