### PR TITLE
Assorted TQoS fixes

### DIFF
--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -1203,7 +1203,7 @@ static int start_tqos(void)
 			"# upload 1:%d: %u-%u%%\n"
 			"\t$TCAUL parent 1:1 classid 1:%d htb rate %ukbit %s %s prio %d quantum %u %s\n"
 			"\t$TQAUL parent 1:%d handle %d: $SCH\n"
-			"\t$TFAUL parent 1: prio %d protocol ip handle %d fw flowid 1:%d\n",
+			"\t$TFAUL parent 1: prio %d protocol ip u32 match mark %d 7 flowid 1:%d\n",
 				i, rate, ceil,
 				x, calc(bw, rate), s, burst_leaf, (i >= 6) ? 7 : (i + 1), mtu, overheadstr,
 				x, x,
@@ -1286,7 +1286,7 @@ static int start_tqos(void)
 					"# download 2:60: LAN-to-LAN\n"
 					"\t$TCADL parent 2:2 classid 2:60 htb rate 10240000kbit ceil 10240000kbit burst 10000 cburst 10000 prio 6\n"
 					"\t$TQADL parent 2:60 handle 60: pfifo\n"
-					"\t$TFADL parent 2: prio 6 protocol ip handle 6 fw flowid 2:60\n",
+					"\t$TFADL parent 2: prio 6 protocol ip u32 match mark 6 7 flowid 2:60\n",
 						(nvram_get_int("qos_default") + 1) * 10,
 						bw, bw, burst_root, overheadstr
 					);
@@ -1304,7 +1304,7 @@ static int start_tqos(void)
 				"# download 2:%d: %u%%\n"
 				"\t$TCADL parent 2:1 classid 2:%d htb rate %ukbit %s prio %d quantum %u %s\n"
 				"\t$TQADL parent 2:%d handle %d: $SCH\n"
-				"\t$TFADL parent 2: prio %d protocol ip handle %d fw flowid 2:%d\n",
+				"\t$TFADL parent 2: prio %d protocol ip u32 match mark %d 7 flowid 2:%d\n",
 					i, rate,
 					x, calc(bw, rate), burst_leaf, (i >= 6) ? 7 : (i + 1), mtu, overheadstr,
 					x, x,

--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -955,10 +955,8 @@ static int add_qos_rules(char *pcWANIF)
 	}
 #endif
 		fprintf(fn,
-			"-A QOSO -m connmark ! --mark 0x0/0x%x -j RETURN\n"
 			"-A QOSO -j CONNMARK %s 0x%x/0x%x\n"
 			"-A POSTROUTING -o %s -j QOSO\n",
-				class_mask,
 				action, class_num|class_gum, class_mask|class_gum,
 				pcWANIF
 			);
@@ -980,10 +978,8 @@ static int add_qos_rules(char *pcWANIF)
 		}
 #endif
 		fprintf(fn_ipv6,
-			"-A QOSO -m connmark ! --mark 0x0/0x%x -j RETURN\n"
 			"-A QOSO -j CONNMARK %s 0x%x/0x%x\n"
 			"-A POSTROUTING -o %s -j QOSO\n",
-				class_mask,
 				action, class_num|class_gum, class_mask|class_gum,
 				wan6face
 			);

--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -997,11 +997,13 @@ static int add_qos_rules(char *pcWANIF)
 		if ((!g) || ((p = strsep(&g, ",")) == NULL)) continue;
 		if ((inuse & (1 << i)) == 0) continue;
 		if (safe_atoi(p) > 0) {
+			fprintf(fn, "-A PREROUTING -i %s -j CONNMARK --restore-mark --mask 0x%x\n", pcWANIF, class_mask);
 #ifdef CLS_ACT
 			fprintf(fn, "-A PREROUTING -i %s -j IMQ --todev 0\n", pcWANIF);
 #endif
 #ifdef RTCONFIG_IPV6
 			if (fn_ipv6 && ipv6_enabled() && *wan6face) {
+				fprintf(fn_ipv6, "-A PREROUTING -i %s -j CONNMARK --restore-mark --mask 0x%x\n", wan6face, class_mask);
 #ifdef CLS_ACT
 				fprintf(fn_ipv6, "-A PREROUTING -i %s -j IMQ --todev 0\n", wan6face);
 #endif

--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -962,8 +962,6 @@ static int add_qos_rules(char *pcWANIF)
 				action, class_num|class_gum, class_mask|class_gum,
 				pcWANIF
 			);
-		if(manual_return)
-			fprintf(fn , "-A QOSO -j RETURN\n");
 
 #ifdef RTCONFIG_IPV6
 	if (fn_ipv6 && ipv6_enabled() && *wan6face) {
@@ -989,8 +987,6 @@ static int add_qos_rules(char *pcWANIF)
 				action, class_num|class_gum, class_mask|class_gum,
 				wan6face
 			);
-		if(manual_return)
-			fprintf(fn_ipv6, "-A QOSO -j RETURN\n");
 	}
 #endif
 

--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -1106,6 +1106,11 @@ static int start_tqos(void)
 	    case 1:
 		mode = " linklayer atm";
 		break;
+	    case 2:
+		mode = "";
+		obw = obw * 64 / 65;
+		ibw = ibw * 64 / 65;
+		break;
 	}
 
 	/* Egress OBW  -- set the HTB shaper (Classful Qdisc)

--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -1026,7 +1026,7 @@ static int add_qos_rules(char *pcWANIF)
 		fprintf(fn_ipv6, "COMMIT\n");
 		fclose(fn_ipv6);
 		chmod(mangle_fn_ipv6, 0700);
-//		eval("ip6tables-restore", (char*)mangle_fn_ipv6);
+		eval("ip6tables-restore", (char*)mangle_fn_ipv6);
 	}
 #endif
 	run_custom_script("qos-start", 0, "rules", NULL);
@@ -1203,7 +1203,7 @@ static int start_tqos(void)
 			"# upload 1:%d: %u-%u%%\n"
 			"\t$TCAUL parent 1:1 classid 1:%d htb rate %ukbit %s %s prio %d quantum %u %s\n"
 			"\t$TQAUL parent 1:%d handle %d: $SCH\n"
-			"\t$TFAUL parent 1: prio %d protocol ip u32 match mark %d 7 flowid 1:%d\n",
+			"\t$TFAUL parent 1: prio %d u32 match mark %d 7 flowid 1:%d\n",
 				i, rate, ceil,
 				x, calc(bw, rate), s, burst_leaf, (i >= 6) ? 7 : (i + 1), mtu, overheadstr,
 				x, x,
@@ -1286,7 +1286,7 @@ static int start_tqos(void)
 					"# download 2:60: LAN-to-LAN\n"
 					"\t$TCADL parent 2:2 classid 2:60 htb rate 10240000kbit ceil 10240000kbit burst 10000 cburst 10000 prio 6\n"
 					"\t$TQADL parent 2:60 handle 60: pfifo\n"
-					"\t$TFADL parent 2: prio 6 protocol ip u32 match mark 6 7 flowid 2:60\n",
+					"\t$TFADL parent 2: prio 6 u32 match mark 6 7 flowid 2:60\n",
 						(nvram_get_int("qos_default") + 1) * 10,
 						bw, bw, burst_root, overheadstr
 					);
@@ -1304,7 +1304,7 @@ static int start_tqos(void)
 				"# download 2:%d: %u%%\n"
 				"\t$TCADL parent 2:1 classid 2:%d htb rate %ukbit %s prio %d quantum %u %s\n"
 				"\t$TQADL parent 2:%d handle %d: $SCH\n"
-				"\t$TFADL parent 2: prio %d protocol ip u32 match mark %d 7 flowid 2:%d\n",
+				"\t$TFADL parent 2: prio %d u32 match mark %d 7 flowid 2:%d\n",
 					i, rate,
 					x, calc(bw, rate), burst_leaf, (i >= 6) ? 7 : (i + 1), mtu, overheadstr,
 					x, x,

--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -811,14 +811,12 @@ static int add_qos_rules(char *pcWANIF)
 			snprintf(conn, sizeof(conn), "%s", "");
 		}
 		else{
-			snprintf(tmp, sizeof(tmp), "%s", q_min);
-			min = atol(tmp);
+			min = atol(q_min);
 
 			if(strcmp(q_max,"") == 0) // q_max == NULL
 				snprintf(conn, sizeof(conn), "-m connbytes --connbytes %ld:%s --connbytes-dir both --connbytes-mode bytes", min*1024, q_max);
 			else{// q_max != NULL
-				snprintf(tmp, sizeof(tmp), "%s", q_max);
-				max = atol(tmp);
+				max = atol(q_max);
 				snprintf(conn, sizeof(conn), "-m connbytes --connbytes %ld:%ld --connbytes-dir both --connbytes-mode bytes", min*1024, max*1024-1);
 			}
 		}

--- a/release/src/router/rc/qos_multiwan.c
+++ b/release/src/router/rc/qos_multiwan.c
@@ -1016,8 +1016,6 @@ static int add_qos_rules(char *pcWANIF)
 		}
 #endif
 			fprintf(fn, "-A %s -j CONNMARK %s 0x%x/0x%x\n", chain, action, class_num, QOS_MASK);
-			if(manual_return)
-				fprintf(fn , "-A %s -j RETURN\n", chain);
 			fprintf(fn, "-A FORWARD -o %s -j %s\n", wan, chain);
 			fprintf(fn, "-A OUTPUT -o %s -j %s\n", wan, chain);
 
@@ -1050,8 +1048,6 @@ static int add_qos_rules(char *pcWANIF)
 			}
 #endif
 			fprintf(fn_ipv6, "-A %s -j CONNMARK %s 0x%x/0x%x\n", chain, action, class_num, QOS_MASK);
-			if(manual_return)
-				fprintf(fn_ipv6, "-A %s -j RETURN\n", chain);
 			fprintf(fn_ipv6, "-A FORWARD -o %s -j %s\n", wan6face, chain);
 			fprintf(fn_ipv6, "-A OUTPUT -o %s -j %s\n", wan6face, chain);
 		}

--- a/release/src/router/rc/qos_multiwan.c
+++ b/release/src/router/rc/qos_multiwan.c
@@ -847,14 +847,12 @@ static int add_qos_rules(char *pcWANIF)
 				sprintf(conn, "%s", "");
 			}
 			else{
-				sprintf(tmp, "%s", q_min);
-				min = atol(tmp);
+				min = atol(q_min);
 
 				if(strcmp(q_max,"") == 0) // q_max == NULL
 					sprintf(conn, "-m connbytes --connbytes %ld:%s --connbytes-dir both --connbytes-mode bytes", min*1024, q_max);
 				else{// q_max != NULL
-					sprintf(tmp, "%s", q_max);
-					max = atol(tmp);
+					max = atol(q_max);
 					sprintf(conn, "-m connbytes --connbytes %ld:%ld --connbytes-dir both --connbytes-mode bytes", min*1024, max*1024-1);
 				}
 			}

--- a/release/src/router/rc/qos_multiwan.c
+++ b/release/src/router/rc/qos_multiwan.c
@@ -1329,7 +1329,7 @@ static int start_tqos(void)
 			fprintf(f, "# egress %d: %u-%u%%\n", i, rate, ceil);
 			fprintf(f, "\t$TCA parent 1:1 classid 1:%d htb rate %ukbit %s %s prio %d quantum %u\n", x, calc(bw, rate), s, burst_leaf, (i >= 6) ? 7 : (i + 1), mtu);
 			fprintf(f, "\t$TQA parent 1:%d handle %d: $SCH\n", x, x);
-			fprintf(f, "\t$TFA parent 1: prio %d protocol ip u32 match mark %d 0x%x flowid 1:%d\n", x, i + 1, QOS_MASK, x);
+			fprintf(f, "\t$TFA parent 1: prio %d u32 match mark %d 0x%x flowid 1:%d\n", x, i + 1, QOS_MASK, x);
 		}
 		free(buf);
 
@@ -1418,7 +1418,7 @@ static int start_tqos(void)
 				fprintf(f, "# ingress %d: %u%%\n", i, rate);
 				fprintf(f,"\t$TCADL parent 2:1 classid 2:%d htb rate %ukbit %s prio %d quantum %u\n", x, calc(bw, rate), burst_leaf, (i >= 6) ? 7 : (i + 1), mtu);
 				fprintf(f,"\t$TQADL parent 2:%d handle %d: $SCH\n", x, x);
-				fprintf(f,"\t$TFADL parent 2: prio %d protocol ip u32 match mark %d 0x%x flowid 2:%d\n", x, i + 1, QOS_MASK, x);
+				fprintf(f,"\t$TFADL parent 2: prio %d u32 match mark %d 0x%x flowid 2:%d\n", x, i + 1, QOS_MASK, x);
 #else
 				x = i + 1;
 				fprintf(f,

--- a/release/src/router/www/QoS_Stats.asp
+++ b/release/src/router/www/QoS_Stats.asp
@@ -375,9 +375,6 @@ function redraw(){
 			document.getElementById('limiter_notice').style.display = "";
 			return;
 		case 0:         // Traditional
-			document.getElementById('dl_tr').style.display = "none";
-			document.getElementById('tqos_notice').style.display = "";
-			break;
 		case 1:		// Adaptive
 		case 3:		// GeForce Now
 			if (pie_obj_dl != undefined) pie_obj_dl.destroy();
@@ -570,7 +567,6 @@ function draw_chart(data_array, ctx, pie) {
 			<div id="limiter_notice" class="hint-color" style="display:none;font-size:125%;;">Note: Statistics not available in Bandwidth Limiter mode.</div>
 			<div id="no_qos_notice" class="hint-color" style="display:none;font-size:125%;">Note: QoS is not enabled.</div>
 			<div id="cake_notice" class="hint-color" style="display:none;font-size:125%;">Note: Statistics not available in Cake mode.</div>
-			<div id="tqos_notice" class="hint-color" style="display:none;font-size:125%;">Note: Traditional QoS only classifies uploaded traffic.</div>
 			<table>
 				<tr id="dl_tr">
 					<td class="hint-color" style="padding-right:50px;font-size:125%;"><div>Download</div><canvas id="pie_chart_dl" width="200" height="200"></canvas></td>


### PR DESCRIPTION
* Fix transfer limits - undefined behaviour was stopping minimums from working
* Allow default rule to work when a transfer limit rule no longer applies
* Basic IPv6 support
* Fix imq0 download classification - mark restoration and masking
* Correct overheads
* Implement PTM
* Restore GUI display for download classification

Fuller detail in individual commit messages.