### PR TITLE
Change the BUG_ON() condition in brcmnand_send_cmd() which checks for the interrupt status "controller ready" bit to a WARN_ON.

### DIFF
--- a/release/src-rt-5.02axhnd.675x/kernel/linux-4.1/drivers/mtd/nand/brcmnand/brcmnand.c
+++ b/release/src-rt-5.02axhnd.675x/kernel/linux-4.1/drivers/mtd/nand/brcmnand/brcmnand.c
@@ -1336,7 +1336,7 @@ static void brcmnand_send_cmd(struct brcmnand_host *host, int cmd)
 			return;
 	} else
 #endif
-	BUG_ON(!(intfc & INTFC_CTLR_READY));
+	WARN_ON(!(intfc & INTFC_CTLR_READY));
 
 	mb(); /* flush previous writes */
 	brcmnand_write_reg(ctrl, BRCMNAND_CMD_START,

--- a/release/src-rt-5.02p1axhnd.675x/kernel/linux-4.1/drivers/mtd/nand/brcmnand/brcmnand.c
+++ b/release/src-rt-5.02p1axhnd.675x/kernel/linux-4.1/drivers/mtd/nand/brcmnand/brcmnand.c
@@ -1336,7 +1336,7 @@ static void brcmnand_send_cmd(struct brcmnand_host *host, int cmd)
 			return;
 	} else
 #endif
-	BUG_ON(!(intfc & INTFC_CTLR_READY));
+	WARN_ON(!(intfc & INTFC_CTLR_READY));
 
 	mb(); /* flush previous writes */
 	brcmnand_write_reg(ctrl, BRCMNAND_CMD_START,


### PR DESCRIPTION
Issue is being discussed here:
https://www.snbforums.com/threads/sporadic-gt-axe11000-reboots-due-to-kernel-panic.77173/

I did Blame for the version of brcmnand.c in https://github.com/torvalds/linux repo and found following commit, done about 6 years ago:
https://github.com/torvalds/linux/commit/422485da15e7e9e6f71a5efd1aa2248595cb486d
which seems will help at least to not to reboot the unit right away in the middle of something critically important.