### PR TITLE
httpd: implement ICMP support for QoS Stats tracked connections

### DIFF
--- a/release/src/router/httpd/data_arrays.c
+++ b/release/src/router/httpd/data_arrays.c
@@ -1114,7 +1114,7 @@ int ej_bwdpi_conntrack(int eid, webs_t wp, int argc, char **argv_) {
 	char line[256];
 	FILE *fp;
 	static unsigned int count = 0;
-	char src_ip[64], dst_ip[64], prot[4];
+	char src_ip[64], dst_ip[64], prot[8];
 	int dport, sport;
 	int ret;
 	unsigned long mark;
@@ -1186,7 +1186,7 @@ int ej_bwdpi_conntrack(int eid, webs_t wp, int argc, char **argv_) {
 
 	while (fgets(line, sizeof(line), fp)) {
 		// ipv4 tcp src=192.168.10.156 dst=172.217.13.110 sport=8248 dport=443 index=8510 mark=3cd000f
-		if (sscanf(line, "ipv%c %3s src=%63s dst=%63s sport=%d dport=%d index=%*d mark=%lx",
+		if (sscanf(line, "ipv%c %7s src=%63s dst=%63s sport=%d dport=%d index=%*d mark=%lx",
 			          &ipversion, prot, src_ip, dst_ip, &sport, &dport, &mark) != 7 ) continue;
 
 		id = (mark & 0x3F0000)/0xFFFF;
@@ -1207,6 +1207,13 @@ int ej_bwdpi_conntrack(int eid, webs_t wp, int argc, char **argv_) {
 		if (ipversion == '6') {
 			_fix_TM_ipv6(src_ip);
 			_fix_TM_ipv6(dst_ip);
+			if ((strcmp(prot,"unknown") == 0) && ((sport == 65535) && (dport == 65535)))
+				strcpy(prot, "icmp");
+		}
+
+		if (strcmp(prot,"icmp") == 0) {
+			sport = 0;
+			dport = 0;
 		}
 
 		ret += websWrite(wp, "%c[\"%s\", \"%s\", \"%d\", \"%s\", \"%d\", \"%s\", \"%d\", \"%d\"]",

--- a/release/src/router/www/QoS_Stats.asp
+++ b/release/src/router/www/QoS_Stats.asp
@@ -289,10 +289,10 @@ function draw_conntrack_table(){
 		code += "<tr><td>" + bwdpi_conntrack[i][0] + "</td>";
 		code += "<td title=\"" + srctitle + "\"" + (srchost.length > 36 ? "style=\"font-size: 80%;\"" : "") +">" +
 	                  srchost + "</td>";
-		code += "<td>" + bwdpi_conntrack[i][2] + "</td>";
+		code += "<td>" + (bwdpi_conntrack[i][0] == "icmp" ? "" : bwdpi_conntrack[i][2]) + "</td>";
 		code += "<td title=\"" + dsttitle + "\"" + (dsthost.length > 36 ? "style=\"font-size: 80%;\"" : "") + ">" +
 		          dsthost + "</td>";
-		code += "<td>" + bwdpi_conntrack[i][4] + "</td>";
+		code += "<td>" + (bwdpi_conntrack[i][0] == "icmp" ? "" : bwdpi_conntrack[i][4]) + "</td>";
 		code += "<td><span title=\"" + label + "\" class=\"catrow cat" +
 	                  qosclass + "\"" + (bwdpi_conntrack[i][5].length > 27 ? "style=\"font-size: 75%;\"" : "") + ">" +
 	                  bwdpi_conntrack[i][5] + "</span></td></tr>";
@@ -593,6 +593,7 @@ function draw_chart(data_array, ctx, pie) {
 						<option value="">any</option>
 						<option value="tcp">tcp</option>
 						<option value="udp">udp</option>
+						<option value="icmp">icmp</option>
 					</select></td>
 					<td><input type="text" class="input_15_table" maxlength="39" oninput="set_filter(1, this);"></input></td>
 					<td><input type="text" class="input_6_table" maxlength="5" oninput="set_filter(2, this);"></input></td>


### PR DESCRIPTION
ICMP traffic is tracked by Adaptive QoS, but only a 3-letter protocol is allowed by the bwdpi function. Increase the possible proto field length from 3 to 7 (e.g. tcp, udp, icmp, unknown).

IPv4 will show the proto as `icmp`. IPv6 shows the proto as `unknown`, but can be replaced with `icmp` if sport and dport equal `65535`.

This has not been compile-tested.

Sample lines from `/proc/bw_cte_dump` for pings:
```
ipv4 icmp src=192.168.1.118 dst=1.1.1.1 sport=65535 dport=65535 index=1755 mark=1090076
ipv6 unknown src=26:01:00:00:00:00:00:00:00:00:00:00:00:00:00: dst=26:06:47:00:47:00:00:00:00:00:00:00:00:00:11: sport=65535 dport=65535 index=2020 mark=1090076
```