### PR TITLE
webui: Display Last 24 Hours Totals in KB when requested

### DIFF
--- a/release/src/router/www/sysdep/FUNCTION/ROG_UI/tmcal.js
+++ b/release/src/router/www/sysdep/FUNCTION/ROG_UI/tmcal.js
@@ -60,10 +60,10 @@ function trafficTotalScale(byt){
 		scale = 'TB';
 	}
 	else{	// unit == 9
-		return scaleSize(byt);
+		value = (byt/1000).toFixed(2);
 	}
 
-	return value + ' <small>'+ scale +'</small>';
+	return comma(value) + ' <small>'+ scale +'</small>';
 }
 
 function xpsb(byt){
@@ -91,7 +91,7 @@ REMOVE-END */
 		value = (byt/1000).toFixed(2);
 	}
 
-	return value + ' <small>'+ scale +'</small>';
+	return comma(value) + ' <small>'+ scale +'</small>';
 }
 
 function showCTab()

--- a/release/src/router/www/sysdep/GT-AC5300/www/tmcal.js
+++ b/release/src/router/www/sysdep/GT-AC5300/www/tmcal.js
@@ -60,10 +60,10 @@ function trafficTotalScale(byt){
 		scale = 'TB';
 	}
 	else{	// unit == 9
-		return scaleSize(byt);
+		value = (byt/1000).toFixed(2);
 	}
 
-	return value + ' <small>'+ scale +'</small>';
+	return comma(value) + ' <small>'+ scale +'</small>';
 }
 
 function xpsb(byt){
@@ -91,7 +91,7 @@ REMOVE-END */
 		value = (byt/1000).toFixed(2);
 	}
 
-	return value + ' <small>'+ scale +'</small>';
+	return comma(value) + ' <small>'+ scale +'</small>';
 }
 
 function showCTab()

--- a/release/src/router/www/tmcal.js
+++ b/release/src/router/www/tmcal.js
@@ -60,10 +60,10 @@ function trafficTotalScale(byt){
 		scale = 'TB';
 	}
 	else{	// unit == 9
-		return scaleSize(byt);
+		value = (byt/1000).toFixed(2);
 	}
 
-	return value + ' <small>'+ scale +'</small>';
+	return comma(value) + ' <small>'+ scale +'</small>';
 }
 
 function xpsb(byt)
@@ -92,7 +92,7 @@ REMOVE-END */
 		value = (byt/1000).toFixed(2);
 	}
 
-	return value + ' <small>'+ scale +'</small>';
+	return comma(value) + ' <small>'+ scale +'</small>';
 }
 
 function showCTab()


### PR DESCRIPTION
Keep units consistent by respecting user dropdown choice. Previous behavior reduced KBs to MB, GB or TB in order to keep the displayed sum less than 10000. Also use comma separators to keep larger numbers more readable.