### PR TITLE
rc: fix tQoS wired download traffic limited by upload bandwidth

### DIFF
--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -1209,10 +1209,9 @@ static int start_tqos(void)
 		"# upload 1:60: LAN-to-LAN (vlan@%s)\n"
 		"\t$TCAUL parent 1:2 classid 1:60 htb rate 1000000kbit ceil 1000000kbit burst 10000 cburst 10000 prio 6\n"
 		"\t$TQAUL parent 1:60 handle 60: pfifo\n"
-		"\t$TFAUL parent 1: prio 6 protocol 802.1q u32 match mark 6 0x%x flowid 1:60\n",
+		"\t$TFAUL parent 1: prio 6 protocol 802.1q u32 match u32 0 0 flowid 1:60\n",
 			wan_ifname,
-			wan_ifname,
-			QOS_MASK
+			wan_ifname
 		);
 #endif
 


### PR DESCRIPTION
All wired download traffic is tagged as vlan1 and was seen on eth0, resulting in wired download traffic being limited to the upload bandwidth setting.

Restore previous behavior of all VLAN-tagged traffic on eth0 to be directed to 1:60 where the bandwidth limit is 1Gbps.

Fixes: 0bc048f77bf7c3f92291d2fba61a1a9e8a323a85 ("rc: tQoS fixes from upstream")