### PR TITLE
fix `JST` time zone error

### DIFF
--- a/release/src/router/rc/common.c
+++ b/release/src/router/rc/common.c
@@ -1389,8 +1389,11 @@ void time_zone_x_mapping(void)
 	nvram_set("time_zone_x", tmpstr);
 
 	/* special mapping */
-	if (nvram_match("time_zone", "JST"))
-		nvram_set("time_zone_x", "UCT-9");
+	if (nvram_match("time_zone", "JST")) {
+		nvram_set("time_zone_x", "UTC-9");
+		snprintf (tmpstr, sizeof(tmpstr), "%s", "JST-9");
+	}
+		
 #if 0
 	else if (nvram_match("time_zone", "TST-10TDT"))
 		nvram_set("time_zone_x", "UCT-10");


### PR DESCRIPTION
1. line 1393: A typo `UCT` to `UTC`
2. line 1394: Write correct `tmpstr` which should be `JST-9` to /etc/TZ

See discussion [Chaotic UTC and local time in merlin](https://www.snbforums.com/threads/chaotic-utc-and-local-time-in-merlin.79268/post-767654) on the SNBForums.

## Validation
Manually revise `/etc/TZ` from `JST` to `JST-9`.
```
# cat /etc/TZ
JST-9
```
Now test the function of `date`.
```
# date
Sat Jun 11 11:19:00 JST 2022
# date -u
Sat Jun 11 02:19:27 UTC 2022
```
Perfect!

Signed-off-by: Shengjiang Quan <qsj287068067@126.com>