### PR TITLE
Add if statement for specific routers to allow compilation on other models.

### DIFF
--- a/release/src/router/rc/sysdeps/init-broadcom.c
+++ b/release/src/router/rc/sysdeps/init-broadcom.c
@@ -5401,7 +5401,9 @@ void generate_wl_para(char *ifname, int unit, int subunit)
 	memset(tmp, 0, sizeof(tmp));
 	memset(tmp2, 0, sizeof(tmp2));
 
+#if defined(RTAC5300) || defined(GTAC5300) || defined(GTAXE16000) || defined(GTAX11000_PRO) || defined(RTAX88U)
 	wl_apply_akm_by_auth_mode(unit, subunit, NULL);
+#endif
 
 	if (nvram_match(strcat_r(prefix, "auth_mode_x", tmp), "radius"))
 	{


### PR DESCRIPTION
This may be temporary however this pr would allow other models to be able to compile the latest version without the "undefined reference error: wl_apply_akm_by_auth_mode". We'd thought we'd share this in case anyone wishes to try out. The latest revision has been tested on the RT-AC88U and works just fine.