### PR TITLE
firmware update: add unique identifier for statistics

### DIFF
--- a/release/src/router/rom/webs_scripts/merlin_webs_update.sh
+++ b/release/src/router/rom/webs_scripts/merlin_webs_update.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 
-wget_options="-q -t 2 -T 30"
+if [ -z "$(nvram get merlin_fwupdate_uuid)" ]; then
+	# If there is no UUID then generate the UUID and save it as a persistent variable for later use.
+	# A factory reset will make it regenerate.
+	uuid="$(cat /proc/sys/kernel/random/uuid)" # generate a uuid
+	nvram set merlin_fwupdate_uuid="$uuid"
+	nvram commit
+fi
+
+if [ "$(nvram get merlin_fwupdate_uuid)" = "0" ]; then
+	# If UUID variable is 0, the original check update method is maintained -- no unique identifier is sent to the update server.
+	wget_options="-q -t 2 -T 30"
+else
+	productid="$(nvram get productid)" # Get router model
+	fw_version="$(nvram get buildno)_$(nvram get extendno)" # Get firmware version
+	uuid="$(nvram get merlin_fwupdate_uuid)" # Get uuid
+	# the unique identifier consists of three pieces of information model-firmware-uuid.
+	wget_options="--user-agent=\"$productid-$fw_version-$uuid\" -q -t 2 -T 30"
+fi
 
 fwsite="https://fwupdate.asuswrt-merlin.net"
 


### PR DESCRIPTION
Add merlin_fwupdate_uuid mvram variable to persist a UUID, UUID is randomly generated, not bound to hardware, and will be reset after factory reset.

Statistics sent to the server are sent through the HTTP user agent in the format: Model-FirmwareVersion-UUID. (ex: RT-AX68U-386.7_2-323fd9e3-7c70-45af-b0de-57caec678e54)

When the merlin_fwupdate_uuid variable is 0, it means that the user has explicitly opted out of statistics collection, will stop sending the unique identifier to the server, and revert to the default behavior of the previous firmware.