### PR TITLE
Remove mention of GitHub issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 asuswrt-merlin New Gen (version 382.xx and higher)
 ==================================================
 
-#### Please do not use Github's Issue tracker for support requests.  Use the support forums at [SNBForums](https://www.snbforums.com/forums/asuswrt-merlin.42/) instead.  The issue tracker is for development/bug tracking purposes only!
+#### Support is available via the forums at [SNBForums](https://www.snbforums.com/forums/asuswrt-merlin.42/).
 
 Asuswrt-Merlin is an enhanced version of Asuswrt, the firmware used by Asus's modern routers.
 


### PR DESCRIPTION
The issue tracker isn't even enabled on this repo, so remove mention of it from the project readme.