### PR TITLE
httpd: Correct hash table detection for the webcgi_init function for …

### DIFF
--- a/release/src/router/httpd/cgi.c
+++ b/release/src/router/httpd/cgi.c
@@ -257,7 +257,7 @@ void webcgi_init(char *query)
        char *q, *end, *name, *value;
  
 #if !(defined(__GLIBC__) || defined(__UBLIBC__))
-	if (!htab.__tab)
+	if (htab.__tab)
 #else
        if (htab.table)
 #endif


### PR DESCRIPTION
…non-glibc/uclibc preprocessor path.

So this is probably a throwaway commit, but in my adventures I found in 908b671963afb2d94076efc2bcec621c879a0689 the logic got reversed for musl targets in webcgi_init. Really does nothing for asuswrt as it takes the glibc path.

Interesting to see that asus toyed with the idea of using musl for their libc though.