### PR TITLE
Never delete nvram.nvm

### DIFF
--- a/release/src/router/busybox/libbb/remove_file.c
+++ b/release/src/router/busybox/libbb/remove_file.c
@@ -97,6 +97,13 @@ int FAST_FUNC remove_file(const char *path, int flags)
 			return 0;
 	}
 
+#if defined(RTCONFIG_HND_ROUTER_AX_6756)
+	if (strstr(path, "nvram.nvm")) {
+		bb_perror_msg("can't remove the system file: '%s'.", path);
+		return -1;
+	}
+#endif
+
 	if (unlink(path) < 0) {
 		bb_perror_msg("can't remove '%s'", path);
 		return -1;


### PR DESCRIPTION
Make sure that the file should not be deleted under any circumstances, including the full path or just the filename or `*`, such as `rm -rf /tmp/*`.