### PR TITLE
webui: remove rstats week option

### DIFF
--- a/release/src/router/www/Tools_OtherSettings.asp
+++ b/release/src/router/www/Tools_OtherSettings.asp
@@ -701,7 +701,6 @@ function done_validating(action){
 								<option value="12" <% nvram_match("rstats_stime", "12","selected"); %>>Every 12 hours</option>
 								<option value="24" <% nvram_match("rstats_stime", "24","selected"); %>>Every 1 day</option>
 								<option value="72" <% nvram_match("rstats_stime", "72","selected"); %>>Every 3 days</option>
-								<option value="168" <% nvram_match("rstats_stime", "168","selected"); %>>Every 1 week</option>
 							</select>
 						</td>
 					</tr>


### PR DESCRIPTION
rstats_stime nvram is only 2 bytes since 382.x and cannot fit the value 168 for the “Every 1 week” dropdown selection.

Ref: https://github.com/RMerl/asuswrt-merlin.ng/commit/83b37275c1ddbf7b5e4e245fd1621201397a89f9