### PR TITLE
others: improve cru locking to prevent concurrent updates

### DIFF
--- a/release/src/router/others/cru
+++ b/release/src/router/others/cru
@@ -6,27 +6,19 @@ N="$F.new"
 L="/var/lock/cron.lock"
 
 if [ $# -gt 1 -a "$1" = "a" -o "$1" = "d" ]; then
-	if [ -f $L ];
-	then
-		I=$((($$ % 25) + 5))
-		while ! rm $L 2>/dev/null; do
-			I=$(($I - 1))
-			[ $I -lt 0 ] && break
-			sleep 1
-		done
-	fi
+	{
+		flock -x 278
+		ID=$2
+		grep -v "#$ID#\$" $F >$N 2>/dev/null
+		if [ "$1" = "a" ]; then
+			shift
+			shift
+			echo "$* #$ID#" >>$N
+		fi
+		mv $N $F
+		echo `nvram get http_username` >>$U
+	} 278>$L
 
-	ID=$2
-	grep -v "#$ID#\$" $F >$N 2>/dev/null
-	if [ "$1" = "a" ]; then
-		shift
-		shift
-		echo "$* #$ID#" >>$N
-	fi
-	mv $N $F
-	echo `nvram get http_username` >>$U
-	
-	echo >$L
 	exit 0
 fi
 


### PR DESCRIPTION
There are reported cases of cron jobs being lost under heavy cru activity (concurrent executions). Protect against concurrent add or deletes with a more robust locking mechanism using flock.

File descriptor 278 is used as it represents the letters C-R-U on a telephone keypad.