### PR TITLE
Removed sorting with netstat-nat, which added 40-45% execution time with many entries.

### DIFF
--- a/release/src/router/httpd/data_arrays.c
+++ b/release/src/router/httpd/data_arrays.c
@@ -1188,7 +1188,7 @@ int ej_connlist_array(int eid, webs_t wp, int argc, char **argv) {
 
 	ret += websWrite(wp, "var connarray = [");
 
-	system("/usr/sbin/netstat-nat -r state -xn > /tmp/connect.log 2>&1");
+	system("/usr/sbin/netstat-nat -xn > /tmp/connect.log 2>&1");
 
 	fp = fopen("/tmp/connect.log", "r");
 	if (fp == NULL) {


### PR DESCRIPTION
When trying to access **System Log - Active Connections** (`Main_ConnStatus_Content.asp`), when there are many (10000+) entries, the operation takes a long time (40-45s on my RT-AX88U) and nothing is displayed. This is due to `netstat-nat` sorting (`-r state`).
If letting the client handle the sorting in the datatable instead, the execution time can be reduced by at least 40%.