### PR TITLE
Fixed sorting when clicking on table header.

### DIFF
--- a/release/src/router/www/Advanced_Wireless_Survey.asp
+++ b/release/src/router/www/Advanced_Wireless_Survey.asp
@@ -80,16 +80,20 @@ function addBorder(obj){
 }
 
 function doSorter(_flag, _Method, flip){
-	if(aplist.length > 1){
+	if(aplist.length > 1) {
+		// Flip sort order (unless told not to)
+		if (sorter.indexFlag == _flag && flip) {
+			sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
+		}
+		else {
+			sorter.sortingMethod = "increase";
+		}
 
 		// Set field to sort
 		sorter.indexFlag = _flag;
 
 		// Remember data type for this field
 		sorter.lastType = _Method;
-
-		// Flip sort order (unless told not to)
-		if (flip) sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
 
 		// doSorter
 		eval("aplist.sort(sorter."+_Method+"_"+sorter.sortingMethod+");");

--- a/release/src/router/www/client_function.js
+++ b/release/src/router/www/client_function.js
@@ -1998,20 +1998,35 @@ var sorter = {
 
 		switch (clickItem) {
 			case "all" :
+				if (sorter.all_index == sorterClickIndex) {
+					sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
+				}
+				else {
+					sorter.sortingMethod = "increase";
+				}
 				sorterLastIndex = sorter.all_index;
 				sorter.all_index = sorterClickIndex;
-				sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
 				break;
 			case "wired" :
+				if (sorter.all_index == sorterClickIndex) {
+					sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
+				}
+				else {
+					sorter.sortingMethod = "increase";
+				}
 				sorterLastIndex = sorter.wired_index;
 				sorter.wired_index = sorterClickIndex;
-				sorter.sortingMethod_wired = (sorter.sortingMethod_wired == "increase") ? "decrease" : "increase";
 				break;
 		}
 		if(clickItem.substr(0,2) == "wl" || isSupport("amas") && clickItem.substr(0,2) == "gn"){
+			if (sorter["sortingMethod_"+clickItem+""] == sorter[""+clickItem+"_index"]) {
+				sorter["sortingMethod_"+clickItem+""] = (sorter["sortingMethod_"+clickItem+""] == "increase") ? "decrease" : "increase";
+			}
+			else {
+				sorter["sortingMethod_"+clickItem+""] = "increase";
+			}
 			sorterLastIndex = sorter[""+clickItem+"_index"];
 			sorter[""+clickItem+"_index"] = sorterClickIndex;
-			sorter["sortingMethod_"+clickItem+""] = (sorter["sortingMethod_"+clickItem+""] == "increase") ? "decrease" : "increase";
 		}
 		obj.parentNode.childNodes[sorterLastIndex].style.boxShadow = "";
 	},

--- a/release/src/router/www/js/table/table.js
+++ b/release/src/router/www/js/table/table.js
@@ -285,7 +285,6 @@ var tableSorter = {
 			tableSorter.sortingMethod = "increase";
 		}
 		tableSorter.indexFlag = _$this.index();
-		tableSorter.sortingMethod = (tableSorter.sortingMethod == "increase") ? "decrease" : "increase";
 		tableSorter.sortingType = _$this.attr("sortType");
 		tableSorter.sortData(tableSorter.indexFlag, tableSorter.sortingType, "tableApi._jsonObj.data");
 		tableApi.genTable(tableApi._jsonObj);

--- a/release/src/router/www/js/table/table.js
+++ b/release/src/router/www/js/table/table.js
@@ -278,6 +278,12 @@ var tableSorter = {
 
 	"doSorter" : function(_$this) {	
 		// update variables
+		if (tableSorter.indexFlag == _$this.index()) {
+			tableSorter.sortingMethod = (tableSorter.sortingMethod == "increase") ? "decrease" : "increase";
+		}
+		else {
+			tableSorter.sortingMethod = "increase";
+		}
 		tableSorter.indexFlag = _$this.index();
 		tableSorter.sortingMethod = (tableSorter.sortingMethod == "increase") ? "decrease" : "increase";
 		tableSorter.sortingType = _$this.attr("sortType");

--- a/release/src/router/www/sysdep/FUNCTION/SITE_SURVEY/Advanced_Wireless_Survey.asp
+++ b/release/src/router/www/sysdep/FUNCTION/SITE_SURVEY/Advanced_Wireless_Survey.asp
@@ -61,14 +61,18 @@ function initial(){
 function doSorter(_flag, _Method, flip){
 	if(aplist.length > 1){
 
+		// Flip sort order (unless told not to)
+		if (sorter.indexFlag == _flag && flip) {
+			sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
+		}
+		else {
+			sorter.sortingMethod = "increase";
+		}
 		// Set field to sort
 		sorter.indexFlag = _flag;
 
 		// Remember data type for this field
 		sorter.lastType = _Method;
-
-		// Flip sort order (unless told not to)
-		if (flip) sorter.sortingMethod = (sorter.sortingMethod == "increase") ? "decrease" : "increase";
 
 		// doSorter
 		eval("aplist.sort(sorter."+_Method+"_"+sorter.sortingMethod+");");


### PR DESCRIPTION
The table sorter is flawed.
When clicking a header it flips the sorting direction every time. Regardless if the header is already selected or not.
Expected behaviour:

- Default sorting direction is increasing on the first column. (Except for Site Survey where signal strength is sorted by descending order by default).
- Clicking a column header that is already selected: flip the direction.
- Clicking a column header which is **not** selected: the sorting direction defaults to increasing.