### PR TITLE
Update merlin_webs_update.sh - Certificate Failure

### DIFF
--- a/release/src/router/rom/webs_scripts/merlin_webs_update.sh
+++ b/release/src/router/rom/webs_scripts/merlin_webs_update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-wget_options="-q -t 2 -T 30"
+wget_options="--no-check-certificate -q -t 2 -T 30"
 
 fwsite="https://fwupdate.asuswrt-merlin.net"
 


### PR DESCRIPTION
Update merlin_webs_update.sh - Certificate Failure

Due to changes to the website: https://fwupdate.asuswrt-merlin.net/manifest2.txt
This script no longer functions correctly, and fails with certificate errors.

![image](https://github.com/RMerl/asuswrt-merlin.ng/assets/1971404/feb273ee-2426-4b23-9b00-220a5d9a4175)

**-TEST ENVIRONMENT:**

Downgrade to 388.6 (or change the nvram values)
Run the **webs_update.sh** script (/usr/sbin/webs_update.sh)
Confirm that no updates are detected by checking the values:

`webs_state_flag`
and
`webs_state_info`

Also confirm that the wlan_update.txt located here: /usr/tmp/wlan_update.txt is empty:

![image](https://github.com/RMerl/asuswrt-merlin.ng/assets/1971404/bf6097fd-4f60-4ffd-9f5b-c7933cd5d955)


**-TROUBLESHOOTING**

Modify the the **webs_update.sh** script (/usr/sbin/webs_update.sh) to include set -u **(temporarily)**
And removed the -q from the `wget_options="-q -t 2 -T 30"` so we can see the errors.

Identified the certificate error here:

![image](https://github.com/RMerl/asuswrt-merlin.ng/assets/1971404/3a74792c-4e2f-4ce4-911f-ab54b1481799)

And confirmed that adding a bypass for the certificate worked and populated the /usr/tmp/wlan_update.txt as expected:

![image](https://github.com/RMerl/asuswrt-merlin.ng/assets/1971404/1d1da4b3-4c4d-41ab-b1d3-e59a6f3187fd)

And that the values for 

`webs_state_flag`
and
`webs_state_info`

Are now correctly set.

![image](https://github.com/RMerl/asuswrt-merlin.ng/assets/1971404/a9ae2946-54d1-471d-9158-feeefa98e05c)


