### PR TITLE
httpd: add two signedness check in httpd/http.c

### DIFF
--- a/release/src/router/httpd/http.c
+++ b/release/src/router/httpd/http.c
@@ -148,6 +148,9 @@ wget(int method, const char *server, char *buf, size_t count, off_t offset)
 			for (s += 15; isblank(*s); s++);
 			chomp(s);
 			len = atoi(s);
+			if (len <= 0) {
+				return -EINVAL;
+			}
 		}
 		else if (!strncasecmp(s, "Transfer-Encoding:", 18)) {
 			for (s += 18; isblank(*s); s++);

--- a/release/src/router/httpd/http.c
+++ b/release/src/router/httpd/http.c
@@ -160,9 +160,13 @@ wget(int method, const char *server, char *buf, size_t count, off_t offset)
 		}
 	}
 
-	if (chunked && fgets(line, sizeof(line), fp))
+	if (chunked && fgets(line, sizeof(line), fp)) {
 		len = strtol(line, NULL, 16);
-	
+		if (len <= 0) {
+			return -EINVAL;
+		}
+	}
+
 	len = (len > count) ? count : len;
 	len = fread(buf, 1, len, fp);
 


### PR DESCRIPTION
Two signedness checks are added to `wget()` function in `httpd/http.c`.
Without the checks, a wget request from the implementation to a malicious server with a crafted `Content-Length` parameter (or a valid `Content-Length` plus a crafted `Transfer-Encoding: chunked`) may lead to a consequent buffer over-read in the statement `len = fread(buf, 1, len, fp);`.