### PR TITLE
Fix namecheap DDNS with let's encrypt

### DIFF
--- a/release/src/router/httpd/gencert.sh
+++ b/release/src/router/httpd/gencert.sh
@@ -210,11 +210,7 @@ echo "DNS.${DNS_I} = www.asusrouter.com" >> ssl_server.ext && DNS_I=$((DNS_I+1))
 # add DDNS if operates in router mode
 if [ "`nvram get sw_mode`" == "1" ] ; then
 	if [ -n "`nvram get ddns_hostname_x`" ] ; then
-		if [ "`nvram get ddns_server_x`" == "WWW.NAMECHEAP.COM" ] ; then
-			echo "DNS.${DNS_I} = `nvram get ddns_username_x`" >> ssl_server.ext && DNS_I=$((DNS_I+1))
-		else
-			echo "DNS.${DNS_I} = `nvram get ddns_hostname_x`" >> ssl_server.ext && DNS_I=$((DNS_I+1))
-		fi
+		echo "DNS.${DNS_I} = `nvram get ddns_hostname_x`" >> ssl_server.ext && DNS_I=$((DNS_I+1))
 		nvram set last_cert_ddns_hostname=`nvram get ddns_hostname_x`
 	fi
 fi

--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -4822,10 +4822,18 @@ start_ddns(char *caller)
 				fprintf(fp, "ddns-server = dynamicdns.park-your-domain.com\n");
 				// We store the domain.tld in the username nvram
 				fprintf(fp, "ddns-path = \"/update?domain=%%u&password=%%p&host=%%h\"\n");
+				// Namecheap username is the top domain (domain.tld)
+				// Namecheap hostname is only the subdomain (sub - not sub.domain.tld)
+				strcpy(tmp, host);
+				char *ptr = strstr(tmp, user);
+				if (ptr != NULL && ptr > tmp + 1) {
+					*--ptr = '\0';
+				}
+				fprintf(fp, "hostname = %s\n", tmp);
 			} else {
 				fprintf(fp, "provider %s {\n", service);
+				fprintf(fp, "hostname = %s\n", host);
 			}
-			fprintf(fp, "hostname = %s\n", host);
 			fprintf(fp, "username = '%s'\n", ppp_safe_escape(user, tmp, sizeof(tmp)));
 			fprintf(fp, "password = '%s'\n", ppp_safe_escape(passwd, tmp, sizeof(tmp)));
 			if (wild)

--- a/release/src/router/www/index.asp
+++ b/release/src/router/www/index.asp
@@ -560,15 +560,7 @@ function show_ddns_status(){
 	var ddnsName;
 	var ddns_hostname_x = '<% nvram_get("ddns_hostname_x"); %>';
 	var ddns_username_x = '<% nvram_get("ddns_username_x"); %>';
-
-	switch (ddns_server_x){
-		case "WWW.NAMECHEAP.COM":
-			ddnsName = ddns_hostname_x + "." + ddns_username_x;
-			break;
-		
-		default:
-			ddnsName = ddns_hostname_x; 
-	}
+	ddnsName = ddns_hostname_x; 
 
 	document.getElementById("ddns_fail_hint").className = "notificationoff";
 	if( ddns_enable == '0'){


### PR DESCRIPTION
Use the hostname field with FQDN, but only store the subdomain - if it exists - to the inadyn.conf file. This allows DDNS with namecheap with let's encrypt. Now one has to decide one or another.