### PR TITLE
Fix gcc-15 build

### DIFF
--- a/release/src/router/config/Makefile
+++ b/release/src/router/config/Makefile
@@ -101,7 +101,7 @@ endif
 .PHONY: ncurses
 
 ncurses:
-	@echo "main() {}" > lxtemp.c
+	@echo "int main() {}" > lxtemp.c
 	@if $(HOSTCC) lxtemp.c $(LIBS) ; then \
 		rm -f lxtemp.c a.out; \
 	else \


### PR DESCRIPTION
gcc-15 complains that main() returns an int.

Without this, gcc errors out early in the build process.  I'm using Fedora 41 to run the builds.