### PR TITLE
Ported CVE-2024-13176 fix for OpenSSL 1.1.1w from Ubuntu Repository.

### DIFF
--- a/release/src/router/openssl-1.1/crypto/bn/bn_exp.c
+++ b/release/src/router/openssl-1.1/crypto/bn/bn_exp.c
@@ -601,7 +601,7 @@ static int MOD_EXP_CTIME_COPY_FROM_PREBUF(BIGNUM *b, int top,
  * out by Colin Percival,
  * http://www.daemonology.net/hyperthreading-considered-harmful/)
  */
-int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
                               const BIGNUM *m, BN_CTX *ctx,
                               BN_MONT_CTX *in_mont)
 {
@@ -617,10 +617,6 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
 #if defined(SPARC_T4_MONT)
     unsigned int t4 = 0;
 #endif
-
-    bn_check_top(a);
-    bn_check_top(p);
-    bn_check_top(m);
 
     if (!BN_is_odd(m)) {
         BNerr(BN_F_BN_MOD_EXP_MONT_CONSTTIME, BN_R_CALLED_WITH_EVEN_MODULUS);
@@ -1141,7 +1137,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
             goto err;
     } else
 #endif
-    if (!BN_from_montgomery(rr, &tmp, mont, ctx))
+    if (!bn_from_mont_fixed_top(rr, &tmp, mont, ctx))
         goto err;
     ret = 1;
  err:
@@ -1153,6 +1149,19 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
     }
     BN_CTX_end(ctx);
     return ret;
+}
+
+int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                              const BIGNUM *m, BN_CTX *ctx,
+                              BN_MONT_CTX *in_mont)
+{
+    bn_check_top(a);
+    bn_check_top(p);
+    bn_check_top(m);
+    if (!bn_mod_exp_mont_fixed_top(rr, a, p, m, ctx, in_mont))
+        return 0;
+    bn_correct_top(rr);
+    return 1;
 }
 
 int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,

--- a/release/src/router/openssl-1.1/crypto/ec/ec_lib.c
+++ b/release/src/router/openssl-1.1/crypto/ec/ec_lib.c
@@ -12,6 +12,7 @@
 
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
+#include "crypto/bn.h"
 
 #include "ec_local.h"
 
@@ -1155,10 +1156,10 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
     if (!BN_sub(e, group->order, e))
         goto err;
     /*-
-     * Exponent e is public.
-     * No need for scatter-gather or BN_FLG_CONSTTIME.
+     * Although the exponent is public we want the result to be
+     * fixed top.
      */
-    if (!BN_mod_exp_mont(r, x, e, group->order, ctx, group->mont_data))
+    if (!bn_mod_exp_mont_fixed_top(r, x, e, group->order, ctx, group->mont_data))
         goto err;
 
     ret = 1;

--- a/release/src/router/openssl-1.1/include/crypto/bn.h
+++ b/release/src/router/openssl-1.1/include/crypto/bn.h
@@ -72,6 +72,9 @@ int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words);
  */
 int bn_mul_mont_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
                           BN_MONT_CTX *mont, BN_CTX *ctx);
+int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                              const BIGNUM *m, BN_CTX *ctx,
+                              BN_MONT_CTX *in_mont);
 int bn_to_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,
                          BN_CTX *ctx);
 int bn_from_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,


### PR DESCRIPTION
The following OpenSSL-1.1.1w patch has been ported from Ubuntu Repository https://packages.ubuntu.com/focal/openssl

CVE-2024-13176 Fix timing side-channel in ECDSA signature computation.

Rework of #867 