### PR TITLE
webui: set correct tab when switching to VLAN Profile sub-tab

### DIFF
--- a/release/src/router/www/state.js
+++ b/release/src/router/www/state.js
@@ -1892,7 +1892,7 @@ function showMenuTree(menuList, menuExclude){
 					tab_code += (j == 0 || j == 3) ? 'tabClicked' : 'tab';	// Show fist tab css as class 'tabClicked'
 				}
 				else if(current_url.indexOf("Advanced_VLAN_Profile_Content") == 0){
-					tab_code += (j == 6) ? 'tabClicked' : 'tab';	// Show 6th tab css as class 'tabClicked'
+					tab_code += (j == 7) ? 'tabClicked' : 'tab';	// Show 7th tab css as class 'tabClicked'
 				}
 				else{
 					tab_code += (j == clickedItem.tab) ? 'tabClicked' : 'tab';


### PR DESCRIPTION
state.js does not account for the presence of the DNS Director tab in this hard-coded tab count, leading to the "Switch Control" tab being highlighted when a user clicks the Profile sub-tab in the VLAN page.