### PR TITLE
webui: Ignore ASUS remote DoT json database on Multiservice WAN page

### DIFF
--- a/release/src/router/www/sysdep/FUNCTION/MULTISERVICE_WAN/Advanced_WAN_Content.asp
+++ b/release/src/router/www/sysdep/FUNCTION/MULTISERVICE_WAN/Advanced_WAN_Content.asp
@@ -1609,6 +1609,7 @@ function initial(){
 					$("#dot_presets_tr").hide();
 			};
 			gen_dotPresets(local_data);
+/*
 			$.getJSON("https://nw-dlcdnet.asus.com/plugin/js/dot-servers.json",
 				function(cloud_data){
 					if(JSON.stringify(local_data) != JSON.stringify(cloud_data)){
@@ -1618,6 +1619,7 @@ function initial(){
 					}
 				}
 			);
+*/
 		});
 	}
 


### PR DESCRIPTION
Prevents unique Merlin entries like Canadian Shield or Adguard from being overwritten by Asus’ remote json file.