### PR TITLE
Update Advanced_WireguardClient_Content.asp

### DIFF
--- a/release/src/router/www/Advanced_WireguardClient_Content.asp
+++ b/release/src/router/www/Advanced_WireguardClient_Content.asp
@@ -307,8 +307,8 @@ function validForm(){
 				return false;
 		}
 		else{
-			isvalid_wgc_aips.isError = true;
-			isvalid_wgc_aips.errReason = "Invalid IP address!";
+			isValid_wgc_aips.isError = true;
+			isValid_wgc_aips.errReason = "Invalid IP address!";
 			return false;
 		}
 	});


### PR DESCRIPTION
Casing Error in Advanced_WireguardClient_Content.asp triggers 'Uncaught ReferenceError: isvalid_wgc_aips is not defined'

This prevents the application of Wireguard Client instance changes.