### PR TITLE
Security: add NVRAM guards to disable infosvr and awsiot

### DIFF
--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -4334,6 +4334,14 @@ int start_awsiot(void)
 	pid_t pid = 0;
 	int ret = 0;
 
+	/* Allow disabling awsiot via NVRAM (security/privacy hardening).
+	 * Uses dedicated key because aae_enable is overwritten by
+	 * convert_defaults() on every boot. */
+	if(nvram_match("disable_awsiot", "1")) {
+		stop_awsiot();
+		return 0;
+	}
+
 	stop_awsiot();
 
 
@@ -4692,6 +4700,12 @@ start_infosvr()
 {
 	char *infosvr_argv[] = {"/usr/sbin/infosvr", "br0", NULL};
 	pid_t pid;
+
+	/* Allow disabling infosvr via NVRAM (security hardening) */
+	if(nvram_match("disable_infosvr", "1")) {
+		stop_infosvr();
+		return 0;
+	}
 
 #ifdef RTCONFIG_MODEM_BRIDGE
 	if(sw_mode() == SW_MODE_AP && nvram_get_int("modem_bridge"))
@@ -7416,9 +7430,7 @@ start_httpd(void)
 		sleep(1);
 #endif
 	}
-#ifndef RTCONFIG_AIHOME_TUNNEL
 	if (enable != 1)
-#endif
 #endif
 	{
 		pid = nvram_get_int("http_lanport") ? : 80;

--- a/release/src/router/rc/watchdog.c
+++ b/release/src/router/rc/watchdog.c
@@ -8090,6 +8090,11 @@ void fbwifi_check()
 void awsiot_check()
 {
 #ifdef RTCONFIG_AWSIOT
+	/* Respect NVRAM disable flag (security/privacy hardening).
+	 * Uses dedicated key because aae_enable is overwritten by
+	 * convert_defaults() on every boot. */
+	if(nvram_match("disable_awsiot", "1"))
+		return;
 	if (!pids("awsiot"))
 		start_awsiot();
 #endif
@@ -11329,6 +11334,9 @@ void feedback_check(void)
 
 void infosvr_check(void)
 {
+	/* Respect NVRAM disable flag (security hardening) */
+	if(nvram_match("disable_infosvr", "1"))
+		return;
 	if (!pids("infosvr"))
 		start_infosvr();
 }


### PR DESCRIPTION
## Summary

- Add `disable_infosvr` and `disable_awsiot` NVRAM flags to allow users to permanently disable these services
- Patch both the startup functions AND the watchdog respawn loops
- Enforce `http_enable=1` (HTTPS-only) even when `RTCONFIG_AIHOME_TUNNEL` is compiled in

## Problem

**infosvr** (UDP/9999) has had critical vulnerabilities (CVE-2014-9583: unauthenticated RCE). In current firmware, any LAN device can send a crafted UDP packet to set `asus_mfg=1`, putting the router into manufacturing mode. The watchdog unconditionally respawns infosvr every 30 seconds, making it impossible to disable at runtime.

**awsiot** maintains a persistent outbound MQTT connection to AWS IoT and can relay admin API calls from the ASUS cloud. The watchdog unconditionally respawns it. The `aae_enable` NVRAM variable cannot be used because `convert_defaults()` overwrites it on every boot.

## Solution

- `nvram_match("disable_infosvr", "1")` guard on `start_infosvr()` and `infosvr_check()`
- `nvram_match("disable_awsiot", "1")` guard on `start_awsiot()` and `awsiot_check()`
- Both call `stop_*()` before returning when disabled (kills running instances)
- Remove `#ifndef RTCONFIG_AIHOME_TUNNEL` guard so `http_enable=1` is always respected

## Activation

```sh
nvram set disable_infosvr=1
nvram set disable_awsiot=1
nvram commit && reboot
```

Default behavior is unchanged — services start normally when keys are not set.

## Test plan
- [ ] Verify services start normally without NVRAM flags
- [ ] Verify `disable_infosvr=1` prevents infosvr from running and watchdog respawn
- [ ] Verify `disable_awsiot=1` prevents awsiot from running and watchdog respawn
- [ ] Verify factory reset clears flags and services resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)