### PR TITLE
webui: restart mastiff when toggling Asusnat tunnel

### DIFF
--- a/release/src/router/www/Tools_OtherSettings.asp
+++ b/release/src/router/www/Tools_OtherSettings.asp
@@ -91,7 +91,7 @@ function applyRule(){
 <input type="hidden" name="next_page" value="Tools_OtherSettings.asp">
 <input type="hidden" name="modified" value="0">
 <input type="hidden" name="action_mode" value="apply">
-<input type="hidden" name="action_script" value="restart_conntrack">
+<input type="hidden" name="action_script" value="restart_conntrack;restart_mastiff">
 <input type="hidden" name="action_wait" value="5">
 <input type="hidden" name="first_time" value="">
 <input type="hidden" name="SystemCmd" value="">


### PR DESCRIPTION
Disabling or enabling the Asusnat tunnel should trigger a restart of the affected services. Restarting mastiff is sufficient.