### PR TITLE
webui: allow dhcp export to work on iOS devices

### DIFF
--- a/release/src/router/www/Advanced_DHCP_Content.asp
+++ b/release/src/router/www/Advanced_DHCP_Content.asp
@@ -772,8 +772,9 @@ function exportCSV(){
 		if(item.mac != "" && item.ip != "")
 			csv += `${item.mac},${item.ip},${item.dns},${item.hostname}\n`;
 	});
+	const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
 	var hiddenElement = document.createElement('a');
-	hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(csv);
+	hiddenElement.href = URL.createObjectURL(blob);
 	hiddenElement.target = '_blank';
 	hiddenElement.download = 'dhcp_manual_list.csv';
 	hiddenElement.click();


### PR DESCRIPTION
This is enough of a change to allow the DHCP list export to work on mobile Safari. Not tested on Windows or Android.