### PR TITLE
feat(vpn-director): add IPv6 policy routing

### DIFF
--- a/release/src/router/libovpn/Makefile
+++ b/release/src/router/libovpn/Makefile
@@ -15,7 +15,7 @@ LDFLAGS += -L$(TOP)/openssl -lcrypto -lssl $(if $(RTCONFIG_OPENSSL11),-lpthread,
 
 INSTALL = install
 
-OBJS = openvpn_config.o openvpn_control.o openvpn_setup.o openvpn_options.o amvpn_routing.o openvpn_utils.o
+OBJS = openvpn_config.o openvpn_control.o openvpn_setup.o openvpn_options.o amvpn_routing.o openvpn_utils.o vpndirector_utils.o
 
 all: libovpn.so
 

--- a/release/src/router/libovpn/amvpn_routing.c
+++ b/release/src/router/libovpn/amvpn_routing.c
@@ -36,16 +36,60 @@
 #include "openvpn_control.h"
 #include "openvpn_setup.h"
 #include "amvpn_routing.h"
+#include "vpndirector_utils.h"
 
 
-// Remove all rules pointing to a specific client table
-// If unit is 0, then remove rules targetting main (i.e. WAN)
-void amvpn_clear_routing_rules(int unit, vpndir_proto_t proto) {
+static void _amvpn_clear_routing_rules_family(int unit, const char *target_table, int ipv6, int verb)
+{
 	FILE *fp;
-	char buffer[128], buffer2[128], buffer3[128];
-	int prio, verb = 3;
-	char table[12], *lookup;
-	char target_table[12];
+	char command[64], line[128], table[12], *lookup;
+	int prio;
+
+	if (ipv6)
+		strlcpy(command, "/usr/sbin/ip -6 rule show", sizeof(command));
+	else
+		strlcpy(command, "/usr/sbin/ip rule show", sizeof(command));
+
+	fp = popen(command, "r");
+	if (!fp)
+		return;
+
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		size_t line_len = strlen(line);
+		if (line_len && line[line_len - 1] == '\n')
+			line[line_len - 1] = '\0';
+
+		if (sscanf(line, "%d", &prio) != 1)
+			continue;
+
+		if ((prio < VPNDIR_PRIO_BASE) ||
+		    (prio > (VPNDIR_PRIO_BASE + (OVPN_CLIENT_MAX + WG_CLIENT_MAX) + VPNDIR_PRIO_MAX_RULES +
+		             (OVPN_CLIENT_MAX * VPNDIR_PRIO_MAX_RULES) + (WG_CLIENT_MAX * VPNDIR_PRIO_MAX_RULES))))
+			continue;
+
+		if ((lookup = strstr(line, "lookup")) == NULL)
+			continue;
+
+		if (sscanf(lookup, "lookup %11s", table) != 1 || strcmp(table, target_table))
+			continue;
+
+		if (ipv6)
+			snprintf(command, sizeof(command), "/usr/sbin/ip -6 rule del prio %d", prio);
+		else
+			snprintf(command, sizeof(command), "/usr/sbin/ip rule del prio %d", prio);
+		if (verb >= 6)
+			logmessage("vpndirector", "Removed IPv%d rule %d", ipv6 ? 6 : 4, prio);
+		system(command);
+	}
+
+	pclose(fp);
+}
+
+// Remove all rules pointing to a specific client table.
+// If unit is 0, then remove rules targeting main (i.e. WAN).
+void amvpn_clear_routing_rules(int unit, vpndir_proto_t proto) {
+	int verb = 3;
+	char buffer[32], target_table[12];
 
 	if (proto == VPNDIR_PROTO_OPENVPN) {
 		snprintf(buffer, sizeof (buffer), "vpn_client%d_verb", unit);
@@ -58,49 +102,21 @@ void amvpn_clear_routing_rules(int unit, vpndir_proto_t proto) {
 		return;
 	}
 
-	snprintf(buffer, sizeof (buffer), "/usr/sbin/ip rule show > /tmp/vpnrules%d_tmp", unit);
-	system(buffer);
-
-	snprintf(buffer, sizeof (buffer), "/tmp/vpnrules%d_tmp", unit);
-	fp = fopen(buffer, "r");
-	if (fp) {
-		if (unit == 0)
-			strlcpy(target_table, "main", sizeof (target_table));
-		else if (proto == VPNDIR_PROTO_OPENVPN)
-			snprintf(target_table, sizeof (target_table), "ovpnc%d", unit);
+	if (unit == 0)
+		strlcpy(target_table, "main", sizeof(target_table));
+	else if (proto == VPNDIR_PROTO_OPENVPN)
+		snprintf(target_table, sizeof(target_table), "ovpnc%d", unit);
 #ifdef RTCONFIG_WIREGUARD
-		else if (proto == VPNDIR_PROTO_WIREGUARD)
-			snprintf(target_table, sizeof (target_table), "wgc%d", unit);
+	else if (proto == VPNDIR_PROTO_WIREGUARD)
+		snprintf(target_table, sizeof(target_table), "wgc%d", unit);
 #endif
-		while (fgets(buffer2, sizeof(buffer2), fp) != NULL) {
-			if (buffer2[strlen(buffer2)-1] == '\n')
-				buffer2[strlen(buffer2)-1] = '\0';
+	else
+		return;
 
-			if (sscanf(buffer2, "%u", &prio) != 1)
-				continue;
-
-			// Only remove rules within our official range
-			// max = base + 10 all + (200 wan) + (5 * 200 ovpn) + (5 * 200 wg)
-			if ((prio < VPNDIR_PRIO_BASE) ||
-			     (prio > (VPNDIR_PRIO_BASE + (OVPN_CLIENT_MAX + WG_CLIENT_MAX) + VPNDIR_PRIO_MAX_RULES + (OVPN_CLIENT_MAX * VPNDIR_PRIO_MAX_RULES) + (WG_CLIENT_MAX * VPNDIR_PRIO_MAX_RULES))))
-				continue;
-
-			if ((lookup = strstr(buffer2, "lookup")) == NULL)
-				continue;
-
-			if (sscanf(lookup, "lookup %11s", table) != 1)
-				continue;
-			if (strcmp(table, target_table))
-				continue;
-
-			snprintf(buffer3, sizeof (buffer3), "/usr/sbin/ip rule del prio %d", prio);
-			if (verb >= 6)
-				logmessage("vpndirector", "Removed rule %d", prio);
-			system(buffer3);
-		}
-		fclose(fp);
-	}
-	unlink(buffer);
+	_amvpn_clear_routing_rules_family(unit, target_table, 0, verb);
+#ifdef RTCONFIG_IPV6
+	_amvpn_clear_routing_rules_family(unit, target_table, 1, verb);
+#endif
 
 #if defined(RTCONFIG_WIREGUARD) && (defined(RTCONFIG_HND_ROUTER_AX_6756) || defined(RTCONFIG_BCM_502L07P2) || defined(RTCONFIG_HND_ROUTER_AX_675X)) || defined(RTCONFIG_HND_ROUTER_BE_4916)
 	// Remove all bypass for this unit
@@ -261,13 +277,47 @@ void amvpn_set_routing_rules(int unit, vpndir_proto_t proto) {
 }
 
 
+static void _amvpn_add_routing_rule(vpndir_addr_family_t family, const char *source,
+	const char *destination, const char *table, int priority)
+{
+	char priority_str[12];
+
+	snprintf(priority_str, sizeof(priority_str), "%d", priority);
+	if (family == VPNDIR_ADDR_IPV6) {
+		if (source && destination)
+			eval("/usr/sbin/ip", "-6", "rule", "add", "from", (char *)source, "to", (char *)destination,
+				"table", (char *)table, "priority", priority_str);
+		else if (source)
+			eval("/usr/sbin/ip", "-6", "rule", "add", "from", (char *)source,
+				"table", (char *)table, "priority", priority_str);
+		else if (destination)
+			eval("/usr/sbin/ip", "-6", "rule", "add", "to", (char *)destination,
+				"table", (char *)table, "priority", priority_str);
+		else
+			eval("/usr/sbin/ip", "-6", "rule", "add", "table", (char *)table, "priority", priority_str);
+	} else {
+		if (source && destination)
+			eval("/usr/sbin/ip", "rule", "add", "from", (char *)source, "to", (char *)destination,
+				"table", (char *)table, "priority", priority_str);
+		else if (source)
+			eval("/usr/sbin/ip", "rule", "add", "from", (char *)source,
+				"table", (char *)table, "priority", priority_str);
+		else if (destination)
+			eval("/usr/sbin/ip", "rule", "add", "to", (char *)destination,
+				"table", (char *)table, "priority", priority_str);
+		else
+			eval("/usr/sbin/ip", "rule", "add", "table", (char *)table, "priority", priority_str);
+	}
+}
+
 void _write_routing_rules(int unit, char *rules, int verb, vpndir_proto_t proto) {
 	char *buffer_tmp, *buffer_tmp2, *rule;
-	char buffer[128], table[16];
+	char table[16];
 	int ruleprio, vpnprio, wanprio;
 	char *enable, *desc, *target, *src, *dst;
-	char srcstr[64], dststr[64];
+	vpndir_addr_family_t source_family, destination_family, rule_family;
 #if defined(RTCONFIG_WIREGUARD) && (defined(RTCONFIG_HND_ROUTER_AX_6756) || defined(RTCONFIG_BCM_502L07P2) || defined(RTCONFIG_HND_ROUTER_AX_675X)) || defined(RTCONFIG_HND_ROUTER_BE_4916)
+	char buffer[128];
 	int ret;
 	char bypass_filename[64];
 #endif
@@ -312,8 +362,19 @@ void _write_routing_rules(int unit, char *rules, int verb, vpndir_proto_t proto)
 		else
 			continue;
 
-		if (*src && strcmp(src, "0.0.0.0")) {
-			snprintf(srcstr, sizeof (srcstr), "from %s", src);
+		source_family = vpndir_address_family(src);
+		destination_family = vpndir_address_family(dst);
+		rule_family = vpndir_rule_address_family(src, dst);
+		if (rule_family == VPNDIR_ADDR_INVALID) {
+			logmessage("vpndirector", "Skipping invalid or mixed-family rule %s", desc);
+			continue;
+		}
+		if (proto == VPNDIR_PROTO_OPENVPN && rule_family == VPNDIR_ADDR_IPV6) {
+			logmessage("vpndirector", "Skipping IPv6 OpenVPN rule %s: the OpenVPN routing table is IPv4-only", desc);
+			continue;
+		}
+
+		if (source_family != VPNDIR_ADDR_ANY) {
 #if defined(RTCONFIG_WIREGUARD) && (defined(RTCONFIG_HND_ROUTER_AX_6756) || defined(RTCONFIG_BCM_502L07P2) || defined(RTCONFIG_HND_ROUTER_AX_675X)) || defined(RTCONFIG_HND_ROUTER_BE_4916)
 			if ((proto == VPNDIR_PROTO_WIREGUARD) && (!strncmp(target,"WGC", 3))) {
 				snprintf(bypass_filename, sizeof (bypass_filename), "/etc/wg/vpndirector%d", unit);
@@ -335,7 +396,6 @@ void _write_routing_rules(int unit, char *rules, int verb, vpndir_proto_t proto)
 #endif
 		}
 		else {
-			*srcstr = '\0';
 #if defined(RTCONFIG_WIREGUARD) && (defined(RTCONFIG_HND_ROUTER_AX_6756) || defined(RTCONFIG_BCM_502L07P2) || defined(RTCONFIG_HND_ROUTER_AX_675X)) || defined(RTCONFIG_HND_ROUTER_BE_4916)
 			if ((proto == VPNDIR_PROTO_WIREGUARD) && (!strncmp(target,"WGC", 3))) {
 				snprintf(bypass_filename, sizeof (bypass_filename), "/etc/wg/vpndirector%d", unit);
@@ -347,24 +407,36 @@ void _write_routing_rules(int unit, char *rules, int verb, vpndir_proto_t proto)
 #endif
 		}
 
-		if (*dst && strcmp(dst, "0.0.0.0"))
-			snprintf(dststr, sizeof (dststr), "to %s", dst);
-		else
-			*dststr = '\0';
-
-		snprintf(buffer, sizeof (buffer), "/usr/sbin/ip rule add %s %s table %s priority %d",
-				                                   srcstr, dststr, table, ruleprio);
-
 		if (verb >= 3)
 			logmessage("vpndirector","Routing %s from %s to %s through %s", desc, (*src ? src : "any"), (*dst ? dst : "any"), table);
 
-		system(buffer);
+		if (rule_family == VPNDIR_ADDR_ANY) {
+			_amvpn_add_routing_rule(VPNDIR_ADDR_IPV4, NULL, NULL, table, ruleprio);
+#ifdef RTCONFIG_IPV6
+			if (proto != VPNDIR_PROTO_OPENVPN && ipv6_enabled())
+				_amvpn_add_routing_rule(VPNDIR_ADDR_IPV6, NULL, NULL, table, ruleprio);
+#endif
+		} else if (rule_family == VPNDIR_ADDR_IPV4) {
+			_amvpn_add_routing_rule(VPNDIR_ADDR_IPV4,
+				source_family == VPNDIR_ADDR_IPV4 ? src : NULL,
+				destination_family == VPNDIR_ADDR_IPV4 ? dst : NULL, table, ruleprio);
+		}
+#ifdef RTCONFIG_IPV6
+		else if (ipv6_enabled()) {
+			_amvpn_add_routing_rule(VPNDIR_ADDR_IPV6,
+				source_family == VPNDIR_ADDR_IPV6 ? src : NULL,
+				destination_family == VPNDIR_ADDR_IPV6 ? dst : NULL, table, ruleprio);
+		}
+#endif
 	}
 	free(buffer_tmp);
 }
 
 inline void _flush_routing_cache() {
-        system("/usr/sbin/ip route flush cache");
+	system("/usr/sbin/ip route flush cache");
+#ifdef RTCONFIG_IPV6
+	system("/usr/sbin/ip -6 route flush cache");
+#endif
 }
 
 
@@ -801,6 +873,42 @@ void wgc_set_exclusive_dns(int unit) {
    the rules.
 */
 
+static void _amvpn_clear_killswitch_priority(int priority)
+{
+	char command[256];
+
+	snprintf(command, sizeof(command), "ip rule show priority %d | while read -r rule; do ip rule del priority %d; done", priority, priority);
+	system(command);
+#ifdef RTCONFIG_IPV6
+	snprintf(command, sizeof(command), "ip -6 rule show priority %d | while read -r rule; do ip -6 rule del priority %d; done", priority, priority);
+	system(command);
+#endif
+}
+
+static void _amvpn_add_killswitch_source(vpndir_addr_family_t family, const char *source, const char *priority)
+{
+	if (family == VPNDIR_ADDR_IPV6)
+		eval("ip", "-6", "rule", "add", "from", (char *)source, "priority", (char *)priority, "prohibit");
+	else
+		eval("ip", "rule", "add", "from", (char *)source, "priority", (char *)priority, "prohibit");
+}
+
+static void _amvpn_add_killswitch_destination(vpndir_addr_family_t family, const char *destination, const char *priority)
+{
+	if (family == VPNDIR_ADDR_IPV6)
+		eval("ip", "-6", "rule", "add", "to", (char *)destination, "priority", (char *)priority, "prohibit");
+	else
+		eval("ip", "rule", "add", "to", (char *)destination, "priority", (char *)priority, "prohibit");
+}
+
+static void _amvpn_add_killswitch_lan(vpndir_addr_family_t family, const char *priority)
+{
+	if (family == VPNDIR_ADDR_IPV6)
+		eval("ip", "-6", "rule", "add", "from", "all", "iif", nvram_safe_get("lan_ifname"), "priority", (char *)priority, "prohibit");
+	else
+		eval("ip", "rule", "add", "from", "all", "iif", nvram_safe_get("lan_ifname"), "priority", (char *)priority, "prohibit");
+}
+
 void amvpn_clear_killswitch_rules(vpndir_proto_t proto, int unit, char *sdn_ifname) {
 	int prio, verb = 3;
 	char buffer[256], prio_str[6];
@@ -816,20 +924,18 @@ void amvpn_clear_killswitch_rules(vpndir_proto_t proto, int unit, char *sdn_ifna
 		snprintf(buffer, sizeof (buffer), "vpn_client%d_verb", unit);
 		verb = nvram_get_int(buffer);
 
-		// Delete as many priority "prio" as there are rules of that priority
-		snprintf(buffer, sizeof (buffer), "ip rule show priority %d | while read -r rule; do ip rule del priority %d; done", prio, prio);
+		// Delete as many rules at this priority as exist, in both address families.
+		_amvpn_clear_killswitch_priority(prio);
 		if (verb > 3)
 			logmessage("openvpn-routing", "Clearing killswitch for OpenVPN unit %d", unit);
-		system(buffer);
 #ifdef RTCONFIG_WIREGUARD
 	} else if (proto == VPNDIR_PROTO_WIREGUARD) {
 		prio = VPNDIR_PRIO_KS_WIREGUARD + unit - 1;
 
-		// Delete as many priority "prio" as there are rules of that priority
-		snprintf(buffer, sizeof (buffer), "ip rule show priority %d | while read -r rule; do ip rule del priority %d; done", prio, prio);
+		// Delete as many rules at this priority as exist, in both address families.
+		_amvpn_clear_killswitch_priority(prio);
 		if (verb > 3)
 			logmessage("openvpn-routing", "Clearing killswitch for WireGuard unit %d", unit);
-		system(buffer);
 #endif
 	}
 
@@ -876,6 +982,7 @@ void amvpn_set_killswitch_rules(vpndir_proto_t proto, int unit, char *sdn_ifname
 	char *buffer_tmp, *buffer_tmp2, *rule;
 	char *enable, *desc, *target, *src, *dst;
 	int killswitch, rgw, verb = 3;
+	vpndir_addr_family_t source_family, destination_family, rule_family;
 #ifdef RTCONFIG_MULTILAN_CFG
 	int vpnc_idx, i;
 	MTLAN_T *pmtl = NULL;
@@ -900,7 +1007,7 @@ void amvpn_set_killswitch_rules(vpndir_proto_t proto, int unit, char *sdn_ifname
 			return;
 
 		if (rgw == OVPN_RGW_ALL) {
-			eval("ip", "rule", "add", "from", "all", "iif", nvram_safe_get("lan_ifname"), "priority", prio_str, "prohibit");
+			_amvpn_add_killswitch_lan(VPNDIR_ADDR_IPV4, prio_str);
 			if (verb > 3)
 				logmessage("openvpn-routing","Setting global killswitch rule for OpenVPN client %d", unit);
 		} else if (rgw == OVPN_RGW_POLICY) {
@@ -918,11 +1025,23 @@ void amvpn_set_killswitch_rules(vpndir_proto_t proto, int unit, char *sdn_ifname
 				if (!strcmp(target,"WAN"))
 					continue;
 
-				if (!strncmp(target, "OVPN", 4) && *src && strcmp(src, "0.0.0.0")) {
-					// Create deny rule
-					eval("ip", "rule", "add", "from", src, "priority", prio_str, "prohibit");
-					if (verb > 3)
-						logmessage("openvpn-routing","Setting killswitch rule for %s", src);
+				source_family = vpndir_address_family(src);
+				destination_family = vpndir_address_family(dst);
+				rule_family = vpndir_rule_address_family(src, dst);
+				if (!strncmp(target, "OVPN", 4) && rule_family != VPNDIR_ADDR_INVALID && rule_family != VPNDIR_ADDR_IPV6) {
+					if (source_family != VPNDIR_ADDR_ANY) {
+						_amvpn_add_killswitch_source(source_family, src, prio_str);
+						if (verb > 3)
+							logmessage("openvpn-routing", "Setting killswitch rule for %s", src);
+					} else if (destination_family != VPNDIR_ADDR_ANY) {
+						_amvpn_add_killswitch_destination(destination_family, dst, prio_str);
+						if (verb > 3)
+							logmessage("openvpn-routing", "Setting killswitch rule for destination %s", dst);
+					} else {
+						_amvpn_add_killswitch_lan(VPNDIR_ADDR_IPV4, prio_str);
+						if (verb > 3)
+							logmessage("openvpn-routing", "Setting global killswitch rule for OpenVPN client %d", unit);
+					}
 				}
 			}
 			free(buffer_tmp);
@@ -982,11 +1101,27 @@ void amvpn_set_killswitch_rules(vpndir_proto_t proto, int unit, char *sdn_ifname
 			if (!strcmp(target,"WAN"))
 				continue;
 
-			if (!strncmp(target, "WGC", 3) && *src && strcmp(src, "0.0.0.0")) {
-				// Create deny rule
-				eval("ip", "rule", "add", "from", src, "priority", prio_str, "prohibit");
-				if (verb > 3)
-					logmessage("openvpn-routing","Setting killswitch rule for %s", src);
+			source_family = vpndir_address_family(src);
+			destination_family = vpndir_address_family(dst);
+			rule_family = vpndir_rule_address_family(src, dst);
+			if (!strncmp(target, "WGC", 3) && rule_family != VPNDIR_ADDR_INVALID) {
+				if (source_family != VPNDIR_ADDR_ANY) {
+					_amvpn_add_killswitch_source(source_family, src, prio_str);
+					if (verb > 3)
+						logmessage("openvpn-routing", "Setting killswitch rule for %s", src);
+				} else if (destination_family != VPNDIR_ADDR_ANY) {
+					_amvpn_add_killswitch_destination(destination_family, dst, prio_str);
+					if (verb > 3)
+						logmessage("openvpn-routing", "Setting killswitch rule for destination %s", dst);
+				} else {
+					_amvpn_add_killswitch_lan(VPNDIR_ADDR_IPV4, prio_str);
+#ifdef RTCONFIG_IPV6
+					if (ipv6_enabled())
+						_amvpn_add_killswitch_lan(VPNDIR_ADDR_IPV6, prio_str);
+#endif
+					if (verb > 3)
+						logmessage("openvpn-routing", "Setting global killswitch rule for WireGuard client %d", unit);
+				}
 			}
 		}
 		free(buffer_tmp);

--- a/release/src/router/libovpn/tests/test_vpndirector_utils.c
+++ b/release/src/router/libovpn/tests/test_vpndirector_utils.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "../vpndirector_utils.h"
+
+static void test_address_family_detection(void)
+{
+	assert(vpndir_address_family("") == VPNDIR_ADDR_ANY);
+	assert(vpndir_address_family("0.0.0.0") == VPNDIR_ADDR_ANY);
+	assert(vpndir_address_family("::") == VPNDIR_ADDR_IPV6);
+	assert(vpndir_address_family("::/0") == VPNDIR_ADDR_IPV6);
+	assert(vpndir_address_family("192.0.2.20") == VPNDIR_ADDR_IPV4);
+	assert(vpndir_address_family("192.0.2.0/24") == VPNDIR_ADDR_IPV4);
+	assert(vpndir_address_family("2001:db8:50::204") == VPNDIR_ADDR_IPV6);
+	assert(vpndir_address_family("2001:db8:50::/64") == VPNDIR_ADDR_IPV6);
+}
+
+static void test_invalid_addresses_are_rejected(void)
+{
+	assert(vpndir_address_family("192.0.2.1/33") == VPNDIR_ADDR_INVALID);
+	assert(vpndir_address_family("192.0.2.1/+1") == VPNDIR_ADDR_INVALID);
+	assert(vpndir_address_family("2001:db8::/129") == VPNDIR_ADDR_INVALID);
+	assert(vpndir_address_family("2001:db8::/-0") == VPNDIR_ADDR_INVALID);
+	assert(vpndir_address_family("not-an-address") == VPNDIR_ADDR_INVALID);
+}
+
+static void test_rule_family_rejects_mixed_ip_versions(void)
+{
+	assert(vpndir_rule_address_family("2001:db8:50::/64", "") == VPNDIR_ADDR_IPV6);
+	assert(vpndir_rule_address_family("", "2001:db8:60::/64") == VPNDIR_ADDR_IPV6);
+	assert(vpndir_rule_address_family("192.0.2.0/24", "") == VPNDIR_ADDR_IPV4);
+	assert(vpndir_rule_address_family("", "") == VPNDIR_ADDR_ANY);
+	assert(vpndir_rule_address_family("192.0.2.0/24", "2001:db8:60::/64") == VPNDIR_ADDR_INVALID);
+}
+
+int main(void)
+{
+	test_address_family_detection();
+	test_invalid_addresses_are_rejected();
+	test_rule_family_rejects_mixed_ip_versions();
+	puts("vpndirector utility tests passed");
+	return 0;
+}

--- a/release/src/router/libovpn/vpndirector_utils.c
+++ b/release/src/router/libovpn/vpndirector_utils.c
@@ -1,0 +1,81 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "vpndirector_utils.h"
+
+static int _vpndir_valid_prefix_length(const char *prefix, unsigned int maximum)
+{
+	const char *p;
+	char *end = NULL;
+	unsigned long value;
+
+	if (!prefix || !*prefix)
+		return 0;
+
+	for (p = prefix; *p; ++p) {
+		if (*p < '0' || *p > '9')
+			return 0;
+	}
+
+	errno = 0;
+	value = strtoul(prefix, &end, 10);
+	return errno == 0 && end && *end == '\0' && value <= maximum;
+}
+
+vpndir_addr_family_t vpndir_address_family(const char *address)
+{
+	char host[INET6_ADDRSTRLEN];
+	const char *slash;
+	size_t host_len;
+	struct in_addr addr4;
+	struct in6_addr addr6;
+
+	if (!address || !*address || !strcmp(address, "0.0.0.0"))
+		return VPNDIR_ADDR_ANY;
+
+	slash = strchr(address, '/');
+	if (slash) {
+		if (strchr(slash + 1, '/'))
+			return VPNDIR_ADDR_INVALID;
+		host_len = (size_t)(slash - address);
+	} else {
+		host_len = strlen(address);
+	}
+
+	if (!host_len || host_len >= sizeof(host))
+		return VPNDIR_ADDR_INVALID;
+
+	memcpy(host, address, host_len);
+	host[host_len] = '\0';
+
+	if (inet_pton(AF_INET, host, &addr4) == 1) {
+		if (slash && !_vpndir_valid_prefix_length(slash + 1, 32))
+			return VPNDIR_ADDR_INVALID;
+		return VPNDIR_ADDR_IPV4;
+	}
+
+	if (inet_pton(AF_INET6, host, &addr6) == 1) {
+		if (slash && !_vpndir_valid_prefix_length(slash + 1, 128))
+			return VPNDIR_ADDR_INVALID;
+		return VPNDIR_ADDR_IPV6;
+	}
+
+	return VPNDIR_ADDR_INVALID;
+}
+
+vpndir_addr_family_t vpndir_rule_address_family(const char *source, const char *destination)
+{
+	vpndir_addr_family_t source_family = vpndir_address_family(source);
+	vpndir_addr_family_t destination_family = vpndir_address_family(destination);
+
+	if (source_family == VPNDIR_ADDR_INVALID || destination_family == VPNDIR_ADDR_INVALID)
+		return VPNDIR_ADDR_INVALID;
+
+	if (source_family != VPNDIR_ADDR_ANY && destination_family != VPNDIR_ADDR_ANY &&
+	    source_family != destination_family)
+		return VPNDIR_ADDR_INVALID;
+
+	return source_family != VPNDIR_ADDR_ANY ? source_family : destination_family;
+}

--- a/release/src/router/libovpn/vpndirector_utils.h
+++ b/release/src/router/libovpn/vpndirector_utils.h
@@ -1,0 +1,14 @@
+#ifndef _VPNDIRECTOR_UTILS_H
+#define _VPNDIRECTOR_UTILS_H
+
+typedef enum {
+	VPNDIR_ADDR_INVALID = -1,
+	VPNDIR_ADDR_ANY = 0,
+	VPNDIR_ADDR_IPV4 = 4,
+	VPNDIR_ADDR_IPV6 = 6
+} vpndir_addr_family_t;
+
+vpndir_addr_family_t vpndir_address_family(const char *address);
+vpndir_addr_family_t vpndir_rule_address_family(const char *source, const char *destination);
+
+#endif

--- a/release/src/router/rc/wireguard.c
+++ b/release/src/router/rc/wireguard.c
@@ -8,6 +8,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <stdlib.h>
 #include "rc.h"
 
 #define WG_DIR_CONF    "/etc/wg"
@@ -121,7 +122,7 @@ static int _wg_resolv_ep(const char* ep_addr, char* buf, size_t len)
 
 static void _wg_client_ep_route_add(char* prefix, int table)
 {
-	char table_str[8] = {0};
+	char table_str[12] = {0};
 	char wan_gateway[16] = {0};
 	char wan6_gateway[64] = {0};
 	char wan_ifname[8] = {0};
@@ -157,11 +158,11 @@ static void _wg_client_ep_route_add(char* prefix, int table)
 	{
 		v6 = is_valid_ip6(addr);
 		if (table > 0)
-			eval("ip", "route", "add", addr,
+			eval("ip", v6 ? "-6" : "-4", "route", "add", addr,
 				"via", v6 ? wan6_gateway : wan_gateway,
 				"dev", v6 ? wan6_ifname : wan_ifname, "table", table_str);
 		else
-			eval("ip", "route", "add", addr,
+			eval("ip", v6 ? "-6" : "-4", "route", "add", addr,
 				"via", v6 ? wan6_gateway : wan_gateway,
 				"dev", v6 ? wan6_ifname : wan_ifname);
 	}
@@ -176,21 +177,23 @@ static void _wg_client_ep_route_add(char* prefix, int table)
 
 static void _wg_client_ep_route_del(char* prefix, int table)
 {
-	char table_str[8] = {0};
+	char table_str[12] = {0};
 	char buf[1024] = {0};
 	char addr[64] = {0};
 	char* p = NULL;
 	int unit = 1;
+	int v6 = 0;
 
 	snprintf(table_str, sizeof(table_str), "%d", table);
 	snprintf(buf, sizeof(buf), "%s", nvram_pf_safe_get(prefix, "ep_addr_r"));
 
 	foreach(addr, buf, p)
 	{
+		v6 = is_valid_ip6(addr);
 		if (table > 0)
-			eval("ip", "route", "del", addr, "table", table_str);
+			eval("ip", v6 ? "-6" : "-4", "route", "del", addr, "table", table_str);
 		else
-			eval("ip", "route", "del", addr);
+			eval("ip", v6 ? "-6" : "-4", "route", "del", addr);
 	}
 
 	// VPNDirector - update all other client tables
@@ -225,10 +228,12 @@ static void _wg_config_route(char* prefix, char* ifname, int table)
 	char aips[4096] = {0};
 	char buf[128] = {0};
 	char *p = NULL;
-	char table_str[8] = {0};
+	char table_str[12] = {0};
+	int v6 = 0;
 #if !defined(RTCONFIG_MULTILAN_CFG)
 	FILE *fp = NULL;
-	char cmd[256] = {0};
+	char *route_line = NULL;
+	size_t route_line_len = 0;
 #endif
 
 	snprintf(table_str, sizeof(table_str), "%d", table);
@@ -237,19 +242,54 @@ static void _wg_config_route(char* prefix, char* ifname, int table)
 	if (table > 0)
 	{// copy from main
 		eval("ip", "route", "flush", "table", table_str);
-		system("ip route show table main > /tmp/route_tmp");
-		fp = fopen("/tmp/route_tmp", "r");
+		fp = popen("ip route show table main", "r");
 		if(fp)
 		{
-			while(fgets(buf, sizeof(buf), fp))
+			while(getline(&route_line, &route_line_len, fp) != -1)
 			{
-				snprintf(cmd, sizeof(cmd), "ip route add %s table %d ", trim_r(buf), table);
-				//_dprintf("[%s]\n", cmd);
-				system(cmd);
+				char *route = trim_r(route_line);
+				size_t command_len = strlen(route) + 32;
+				char *command = malloc(command_len);
+
+				if (command) {
+					snprintf(command, command_len, "ip route add %s table %d", route, table);
+					system(command);
+					free(command);
+				}
 			}
-			fclose(fp);
+			free(route_line);
+			route_line = NULL;
+			route_line_len = 0;
+			pclose(fp);
 		}
-		unlink("/tmp/route_tmp");
+
+		eval("ip", "-6", "route", "flush", "table", table_str);
+		fp = popen("ip -6 route show table main", "r");
+		if(fp)
+		{
+			while(getline(&route_line, &route_line_len, fp) != -1)
+			{
+				char *route = trim_r(route_line);
+				size_t command_len;
+				char *command;
+
+				if (!strncmp(route, "default", 7))
+					continue;
+
+				command_len = strlen(route) + 35;
+				command = malloc(command_len);
+				if (command) {
+					snprintf(command, command_len, "ip -6 route add %s table %d", route, table);
+					system(command);
+					free(command);
+				}
+			}
+			free(route_line);
+			route_line = NULL;
+			route_line_len = 0;
+			pclose(fp);
+		}
+		eval("ip", "-6", "route", "replace", "unreachable", "default", "table", table_str);
 	}
 #endif
 
@@ -282,18 +322,19 @@ static void _wg_config_route(char* prefix, char* ifname, int table)
 			while (dst[i])
 			{
 				if (table > 0)
-					eval("ip", "route", "add", dst[i], "dev", ifname, "table", table_str);
+					eval("ip", "-6", "route", "add", dst[i], "dev", ifname, "table", table_str);
 				else
-					eval("ip", "route", "add", dst[i], "dev", ifname);
+					eval("ip", "-6", "route", "add", dst[i], "dev", ifname);
 				i++;
 			}
 		}
 		else
 		{
+			v6 = strchr(buf, ':') != NULL;
 			if (table > 0)
-				eval("ip", "route", "add", buf, "dev", ifname, "table", table_str);
+				eval("ip", v6 ? "-6" : "-4", "route", "add", buf, "dev", ifname, "table", table_str);
 			else
-				eval("ip", "route", "add", buf, "dev", ifname);
+				eval("ip", v6 ? "-6" : "-4", "route", "add", buf, "dev", ifname);
 		}
 	}
 }
@@ -1775,6 +1816,8 @@ void stop_wgc(int unit)
 	// VPNDirector - flushing table
 	amvpn_clear_routing_rules(unit, VPNDIR_PROTO_WIREGUARD);
 	snprintf(buffer, sizeof (buffer),"/usr/sbin/ip route flush table wgc%d", unit);
+	system(buffer);
+	snprintf(buffer, sizeof (buffer),"/usr/sbin/ip -6 route flush table wgc%d", unit);
 	system(buffer);
 
 	/// dns

--- a/release/src/router/shared/vpn_utils.c
+++ b/release/src/router/shared/vpn_utils.c
@@ -508,6 +508,11 @@ void hnd_skip_wg_all_lan(int add)
 	char path[128] = {0};
 	char buf[512] = {0};
 	char net[64] = {0}, *next = NULL;
+#ifdef RTCONFIG_IPV6
+	char ipv6_network[64] = {0};
+	const char *ipv6_prefix;
+	int ipv6_prefix_length;
+#endif
 
 	snprintf(path, sizeof(path), "%s/all_%s", WG_DIR_CONF, WG_NAME_SKIP_NET);
 
@@ -522,13 +527,20 @@ void hnd_skip_wg_all_lan(int add)
 		hnd_skip_wg_network(add, buf);
 		f_write_string(path, buf, 0, 0);
 
-#if 0//RTCONFIG_IPV6
+
+#ifdef RTCONFIG_IPV6
 		int v6_service = get_ipv6_service();
 		int dhcp_pd = nvram_get_int(ipv6_nvname("ipv6_dhcp_pd"));
+		ipv6_prefix = nvram_safe_get(ipv6_nvname("ipv6_prefix"));
+		ipv6_prefix_length = nvram_get_int(ipv6_nvname("ipv6_prefix_length"));
 		if ((v6_service == IPV6_NATIVE_DHCP && dhcp_pd)
 		 || v6_service == IPV6_6IN4 || v6_service == IPV6_MANUAL) {
-			snprintf(buf, sizeof(buf), ",%s/%d", nvram_safe_get(ipv6_nvname("ipv6_prefix")), nvram_get_int(ipv6_nvname("ipv6_prefix_length")));
-			f_write_string(path, buf, FW_APPEND, 0);
+			if (is_valid_ip6(ipv6_prefix) && ipv6_prefix_length >= 0 && ipv6_prefix_length <= 128) {
+				snprintf(ipv6_network, sizeof(ipv6_network), "%s/%d", ipv6_prefix, ipv6_prefix_length);
+				hnd_skip_wg_network(add, ipv6_network);
+				snprintf(buf, sizeof(buf), ",%s", ipv6_network);
+				f_write_string(path, buf, FW_APPEND, 0);
+			}
 		}
 #endif
 	}

--- a/release/src/router/www/Advanced_VPNDirector.asp
+++ b/release/src/router/www/Advanced_VPNDirector.asp
@@ -589,17 +589,26 @@ function saveRule(_mode, _rowIdx) {
 	if (!Block_chars(document.getElementById("desc_x"), ["<" ,">" ,"'" ,"%"]))
 		return false;
 
-	if (!validator.ipv4cidr(document.getElementById("remoteIP_x")) ||
-	    !validator.ipv4cidr(document.getElementById("localIP_x"))) {
+	if (!validator.ipcidr(document.getElementById("remoteIP_x")) ||
+	    !validator.ipcidr(document.getElementById("localIP_x"))) {
+		return false;
+	}
+
+	var localIP = $("#localIP_x").val();
+	var remoteIP = $("#remoteIP_x").val();
+	var interface = $("#iface_x").val();
+
+	if (interface.indexOf("OVPN") == 0 && (localIP.indexOf(":") >= 0 || remoteIP.indexOf(":") >= 0)) {
+		alert("IPv6 VPN Director rules are supported by WireGuard clients, not OpenVPN clients.");
 		return false;
 	}
 
 	var ruleArray = new Array();
 	ruleArray["enable"] = ($("#enable_x").prop("checked") ? 1 : 0);
 	ruleArray["description"] = ($("#desc_x").val() != undefined ? $("#desc_x").val() : "");
-	ruleArray["localIP"] = ($("#localIP_x").val() != undefined ? $("#localIP_x").val() : "");
-	ruleArray["remoteIP"] = ($("#remoteIP_x").val() != undefined ? $("#remoteIP_x").val() : "");
-	ruleArray["interface"] = $("#iface_x").val();
+	ruleArray["localIP"] = localIP;
+	ruleArray["remoteIP"] = remoteIP;
+	ruleArray["interface"] = interface;
 
 	if (_mode == "new")
 		vpndirector_rulelist_array.push(ruleArray);
@@ -739,7 +748,7 @@ function applyRule() {
 				<tr>
 					<th>Local IP</th>
 					<td>
-						<input type="text" maxlength="18" class="input_18_table" id="localIP_x" align="left" onKeyPress="return validator.isIPAddrPlusNetmask(this, event)" style="float:left;" onClick="hideClients_Block();" autocomplete="off" autocorrect="off" autocapitalize="off">
+						<input type="text" maxlength="49" class="input_25_table" id="localIP_x" align="left" style="float:left;" onClick="hideClients_Block();" autocomplete="off" autocorrect="off" autocapitalize="off">
 						<img id="pull_arrow" class="pull_arrow" height="16px;" src="/images/unfold_more.svg" align="right" onclick="pullLANIPList(this);" title="<#select_IP#>">
 						<div id="ClientList_Block" class="clientlist_dropdown" style="margin-left:2px;margin-top:27px;width:238px;"></div>
 						<span style="margin-left:3px; line-height:25px;"><#feedback_optional#></span>
@@ -748,13 +757,13 @@ function applyRule() {
 				<tr>
 					<th>Remote IP</th>
 					<td>
-						<input type="text" maxlength="18" class="input_18_table" id="remoteIP_x" onKeyPress="return validator.isIPAddrPlusNetmask(this, event)" autocomplete="off" autocorrect="off" autocapitalize="off"/>
+						<input type="text" maxlength="49" class="input_25_table" id="remoteIP_x" autocomplete="off" autocorrect="off" autocapitalize="off"/>
 						<span><#feedback_optional#></span>
 					</td>
 				</tr>
 			</table>
 			<div class="amng-highlight-color" style="margin:10px 0px;">
-				* IP addresses can be entered in CIDR format (for example, 192.168.1.0/24).
+				* IPv4 and IPv6 addresses can be entered in CIDR format (for example, 192.168.1.0/24 or 2001:db8::/64).
 			</div>
 			<div style="margin-top:15px; justify-content: center; display:flex; flex-direction:row; gap:0.5em;">
 				<input class="button_gen" type="button" onclick="cancelRule();" value="<#CTL_Cancel#>">

--- a/release/src/router/www/validator.js
+++ b/release/src/router/www/validator.js
@@ -13,6 +13,40 @@ var validator = {
 		}
 	},
 
+	ipv6cidr: function(obj){
+		var value = obj.value;
+		var slash = value.indexOf('/');
+		var address = value;
+		var prefix;
+
+		if (value == "")
+			return true;
+
+		if (slash >= 0) {
+			if (value.indexOf('/', slash + 1) >= 0)
+				return false;
+			address = value.substring(0, slash);
+			prefix = value.substring(slash + 1);
+			if (!/^(0|[1-9][0-9]{0,2})$/.test(prefix) || parseInt(prefix, 10) > 128)
+				return false;
+		}
+
+		return address == "::" || validator.isLegal_ipv6({value: address}, 1);
+	},
+
+	ipcidr: function(obj){
+		if (obj.value.indexOf(':') >= 0) {
+			if (validator.ipv6cidr(obj))
+				return true;
+			alert(obj.value+" is not valid. Please enter a valid IPv4 or IPv6 address, optionally in CIDR format.");
+			obj.focus();
+			obj.select();
+			return false;
+		}
+
+		return validator.ipv4cidr(obj);
+	},
+
 	account: function(string_obj, flag){
 		var invalid_char = "";
 


### PR DESCRIPTION
## Summary

Adds IPv6 policy routing support to VPN Director for WireGuard and OpenVPN clients.

- Accept IPv4 or IPv6 CIDRs in VPN Director source/destination fields.
- Reject invalid CIDRs and mixed-family rules explicitly.
- Install and remove matching `ip -6 rule` policies alongside IPv4 rules.
- Extend WireGuard route-table handling for IPv6 endpoints and `AllowedIPs`.
- Add an unreachable IPv6 default route in WireGuard policy tables to avoid WAN fallback when no tunnel route applies.
- Extend IPv6 killswitch rules and the HND WireGuard LAN-bypass list.
- Replace predictable temporary route files in the touched WireGuard path with pipe-based reads.

## Compatibility and scope

Existing IPv4 rule format and behaviour are preserved. Empty source/destination rules remain dual-stack and emit one policy rule per enabled IP family. Rules combining IPv4 with IPv6 are skipped because Linux policy rules cannot match both families in one rule.

This intentionally does not introduce IPv6 DNS DNAT for the existing "Exclusive DNS" feature; that currently uses IPv4 NAT semantics and needs separate design work.

## Validation

- Added focused C tests for IPv4/IPv6 CIDR parsing, address-family detection, prefix limits, and mixed-family rejection.
- Built the new helper with `gcc -std=c11 -Wall -Wextra -Werror` and executed the focused tests.
- Executed JavaScript validation tests for the VPN Director form, including valid IPv4/IPv6 CIDRs and invalid prefix lengths.
- Verified `git diff --check`.
- A full router firmware build and target-router runtime test were not available in this environment because they require a selected ASUS platform configuration and its cross-toolchain.
