### PR TITLE
Fix time-axis tracking in system temperature and 24-hour traffic charts

### DIFF
--- a/release/src/router/www/Main_TrafficMonitor_last24.asp
+++ b/release/src/router/www/Main_TrafficMonitor_last24.asp
@@ -83,6 +83,16 @@ const samplesMax = 2880;
 const updateInt = 30;
 const showBitrate = 1;
 
+function chartTime(index) {
+	var time = new Date(
+		Date.now() -
+		(samplesMax - index - 1) * updateInt * 1000
+	);
+
+	return time.getHours().toString().padStart(2, "0") + ":" +
+		time.getMinutes().toString().padStart(2, "0");
+}
+
 if (isSupport("UI4")){
 	var labelsColor = "#1C1C1E";
 	var gridColor = "#CCC";
@@ -215,9 +225,6 @@ function update_traffic(){
 
 
 function drawGraph(ifname){
-	var now = new Date();
-	var currentHour = now.getHours();
-
 	if (chartObj[ifname].obj != undefined) {
 		chartObj[ifname].obj.update();
 		return;
@@ -268,20 +275,7 @@ function drawGraph(ifname){
 					bodySpacing: 6,
 					callbacks: {
 						title: function(tooltipItems) {
-						// tooltipItems is an array, take the first item
-							var item = tooltipItems[0];
-							var sampleIndex = item.dataIndex;
-
-						// Calculate hours and minutes
-							const totalMinutesAgo = (samplesMax - sampleIndex - 1) * (updateInt / 60);
-							const tooltipTime = new Date();
-							tooltipTime.setHours(now.getHours() - Math.floor(totalMinutesAgo / 60));
-							tooltipTime.setMinutes(now.getMinutes() - (totalMinutesAgo % 60));
-
-						// Format HH:MM
-							const hh = tooltipTime.getHours().toString().padStart(2, '0');
-							const mm = tooltipTime.getMinutes().toString().padStart(2, '0');
-							return "Time: " + hh + ":" + mm;
+							return "Time: " + chartTime(tooltipItems[0].dataIndex);
 						},
 						label: function(context) {
 							var label = context.dataset.label || '';
@@ -320,13 +314,38 @@ function drawGraph(ifname){
 					min: 0,
 					max: samplesMax,
 					grid: { color: gridColor },
+
+					afterBuildTicks: function(scale) {
+						var now = new Date();
+						var hour = new Date(now);
+
+						hour.setMinutes(0, 0, 0);
+
+						var hourIndex =
+							samplesMax - 1 -
+							(now - hour) / (updateInt * 1000);
+
+						var first = Math.ceil(
+							(scale.min - hourIndex) / samplesPerHour
+						);
+
+						var last = Math.floor(
+							(scale.max - hourIndex) / samplesPerHour
+						);
+
+						scale.ticks = [];
+
+						for (var i = first; i <= last; i++) {
+							scale.ticks.push({
+								value: hourIndex + i * samplesPerHour
+							});
+						}
+					},
+
 					ticks: {
 						color: ticksColor,
-						stepSize: samplesPerHour,
 						callback: function(value) {
-							var hourOffset = Math.floor(value / samplesPerHour);
-							var labelHour = (currentHour - (24 - hourOffset)) % 24;
-							return (labelHour < 0 ? labelHour + 24 : labelHour) + ":00";
+							return chartTime(value);
 						}
 					}
 				},

--- a/release/src/router/www/Tools_Sysinfo.asp
+++ b/release/src/router/www/Tools_Sysinfo.asp
@@ -148,7 +148,7 @@ var wifi51data = [];
 var wifi52data = [];
 var wifi6data = [];
 var wifi62data = [];
-
+var tempchartOffset = 0;
 
 function draw_mem_charts(){
 /* Memory */
@@ -278,6 +278,13 @@ function draw_mem_charts(){
 
 
 function draw_temps_charts(){
+	if (cpudata.length > 20 ||
+	    wifi24data.length > 20 ||
+	    wifi51data.length > 20 ||
+	    wifi52data.length > 20 ||
+	    wifi6data.length > 20 ||
+	    wifi62data.length > 20)
+		tempchartOffset += 3;
 	if (cpudata.length > 20)
 		cpudata.shift();
 	if (wifi24data.length > 20)
@@ -411,6 +418,15 @@ function draw_temps_charts(){
 					labels: [0,3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57],
 					ticks: {
 						color: ticksColor,
+						callback: function(value) {
+							var seconds = Number(this.getLabelForValue(value)) + tempchartOffset;
+
+							if (seconds < 60)
+								return seconds;
+
+							return Math.floor(seconds / 60) + ":" +
+								String(seconds % 60).padStart(2, "0");
+						}
 					}
 				},
 				y: {


### PR DESCRIPTION
SNB report found here: https://www.snbforums.com/threads/asuswrt-merlin-3006-102-8-is-now-available.97535/post-998653

- Allow the temperature chart’s x-axis to continue advancing after the initial 57-second window is filled.
- Keep the existing 20-sample rolling data window.
- Format elapsed time as `minutes:seconds` to keep longer durations readable.
- Align hourly x-axis grid lines with actual top-of-hour boundaries.
- Use the same time calculation for both x-axis labels and tooltip timestamps.
- Fix cases where a data point with a tooltip such as `18:01` appeared before the `18:00` grid line.