### PR TITLE
webui: Remove temperature graph x-axis labels

### DIFF
--- a/release/src/router/www/Tools_Sysinfo.asp
+++ b/release/src/router/www/Tools_Sysinfo.asp
@@ -148,7 +148,7 @@ var wifi51data = [];
 var wifi52data = [];
 var wifi6data = [];
 var wifi62data = [];
-var tempchartOffset = 0;
+
 
 function draw_mem_charts(){
 /* Memory */
@@ -278,13 +278,6 @@ function draw_mem_charts(){
 
 
 function draw_temps_charts(){
-	if (cpudata.length > 20 ||
-	    wifi24data.length > 20 ||
-	    wifi51data.length > 20 ||
-	    wifi52data.length > 20 ||
-	    wifi6data.length > 20 ||
-	    wifi62data.length > 20)
-		tempchartOffset += 3;
 	if (cpudata.length > 20)
 		cpudata.shift();
 	if (wifi24data.length > 20)
@@ -418,15 +411,6 @@ function draw_temps_charts(){
 					labels: [0,3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57],
 					ticks: {
 						color: ticksColor,
-						callback: function(value) {
-							var seconds = Number(this.getLabelForValue(value)) + tempchartOffset;
-
-							if (seconds < 60)
-								return seconds;
-
-							return Math.floor(seconds / 60) + ":" +
-								String(seconds % 60).padStart(2, "0");
-						}
 					}
 				},
 				y: {

--- a/release/src/router/www/Tools_Sysinfo.asp
+++ b/release/src/router/www/Tools_Sysinfo.asp
@@ -410,7 +410,7 @@ function draw_temps_charts(){
 				x: {
 					labels: [0,3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57],
 					ticks: {
-						color: ticksColor,
+						display: false,
 					}
 				},
 				y: {


### PR DESCRIPTION
I propose to revert the recent changes by @ExtremeFiretop and just remove the labels completely. The increasing mm:ss labels don't carry much meaning, especially in a graph only covering a 60-second window.

The Traffic Monitor real-time graphs do not have x-axis labels either.

Open to suggestions, arguments, etc. 